### PR TITLE
feat: Xcode 프로젝트 기반 + 도메인 모델 + PathEncoder (#2)

### DIFF
--- a/ClaudeMonitor/Package.swift
+++ b/ClaudeMonitor/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version: 6.1
+
+import PackageDescription
+
+let package = Package(
+    name: "ClaudeMonitor",
+    platforms: [
+        .macOS(.v15)
+    ],
+    targets: [
+        .executableTarget(
+            name: "ClaudeMonitor",
+            path: "Sources/ClaudeMonitor",
+            exclude: ["App/Info.plist", "App/ClaudeMonitor.entitlements"]
+        ),
+        .testTarget(
+            name: "ClaudeMonitorTests",
+            dependencies: ["ClaudeMonitor"],
+            path: "Tests/ClaudeMonitorTests"
+        ),
+    ]
+)

--- a/ClaudeMonitor/Sources/ClaudeMonitor/App/ClaudeMonitor.entitlements
+++ b/ClaudeMonitor/Sources/ClaudeMonitor/App/ClaudeMonitor.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.app-sandbox</key>
+    <false/>
+</dict>
+</plist>

--- a/ClaudeMonitor/Sources/ClaudeMonitor/App/ClaudeMonitorApp.swift
+++ b/ClaudeMonitor/Sources/ClaudeMonitor/App/ClaudeMonitorApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct ClaudeMonitorApp: App {
+    var body: some Scene {
+        Settings {
+            EmptyView()
+        }
+    }
+}

--- a/ClaudeMonitor/Sources/ClaudeMonitor/App/Info.plist
+++ b/ClaudeMonitor/Sources/ClaudeMonitor/App/Info.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>LSUIElement</key>
+    <true/>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+</dict>
+</plist>

--- a/ClaudeMonitor/Sources/ClaudeMonitor/Domain/Models/SessionInfo.swift
+++ b/ClaudeMonitor/Sources/ClaudeMonitor/Domain/Models/SessionInfo.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+struct ProcessInfo: Sendable, Hashable {
+    let pid: Int
+    let tty: String
+    let cwd: String?
+}
+
+struct SessionSnapshot: Sendable, Hashable {
+    let sessionId: String
+    let gitBranch: String
+    let lastAssistantText: String
+    let lastModified: Date
+    let hasError: Bool
+}
+
+struct SessionInfo: Identifiable, Sendable, Hashable {
+    let id: String
+    let pid: Int
+    let tty: String
+    let projectName: String
+    let projectPath: URL
+    let gitBranch: String
+    let lastAssistantText: String
+    let status: SessionStatus
+    let lastUpdated: Date
+}

--- a/ClaudeMonitor/Sources/ClaudeMonitor/Domain/Models/SessionStatus.swift
+++ b/ClaudeMonitor/Sources/ClaudeMonitor/Domain/Models/SessionStatus.swift
@@ -1,0 +1,7 @@
+enum SessionStatus: Sendable, Hashable {
+    case running
+    case idle
+    case completed
+    case error
+    case fileReadError
+}

--- a/ClaudeMonitor/Sources/ClaudeMonitor/Infrastructure/PathEncoder.swift
+++ b/ClaudeMonitor/Sources/ClaudeMonitor/Infrastructure/PathEncoder.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+struct PathEncoder: Sendable {
+    private let claudeProjectsBase: URL
+
+    init(homeDirectory: URL = .homeDirectory) {
+        self.claudeProjectsBase = homeDirectory
+            .appending(path: ".claude/projects", directoryHint: .isDirectory)
+    }
+
+    func encode(path: String) -> String {
+        let normalized = URL(fileURLWithPath: path).standardized.path
+        let collapsed = normalized.split(separator: "/").joined(separator: "/")
+        let withLeadingSlash = normalized.hasPrefix("/") ? "/" + collapsed : collapsed
+        return withLeadingSlash.replacingOccurrences(of: "/", with: "-")
+    }
+
+    func projectDirectory(for path: String) -> URL? {
+        let encoded = encode(path: path)
+        let result = claudeProjectsBase
+            .appending(path: encoded, directoryHint: .isDirectory)
+        guard result.path().hasPrefix(claudeProjectsBase.path()) else { return nil }
+        return result
+    }
+}

--- a/ClaudeMonitor/Tests/ClaudeMonitorTests/PathEncoderTests.swift
+++ b/ClaudeMonitor/Tests/ClaudeMonitorTests/PathEncoderTests.swift
@@ -1,0 +1,72 @@
+import Testing
+import Foundation
+@testable import ClaudeMonitor
+
+@Suite("PathEncoder Tests")
+struct PathEncoderTests {
+
+    let encoder = PathEncoder(homeDirectory: URL(fileURLWithPath: "/tmp/test-home"))
+
+    // MARK: - encode(path:)
+
+    @Test("TC-01: 기본 변환")
+    func encodeBasicPath() {
+        #expect(encoder.encode(path: "/Users/bombo/foo") == "-Users-bombo-foo")
+    }
+
+    @Test("TC-02: 후행 슬래시 제거")
+    func encodeTrailingSlash() {
+        #expect(encoder.encode(path: "/Users/bombo/foo/") == "-Users-bombo-foo")
+    }
+
+    @Test("TC-03: .. 정규화")
+    func encodeDoubleDot() {
+        #expect(encoder.encode(path: "/Users/bombo/../bombo/foo") == "-Users-bombo-foo")
+    }
+
+    @Test("TC-04: . 정규화")
+    func encodeSingleDot() {
+        #expect(encoder.encode(path: "/Users/bombo/./foo") == "-Users-bombo-foo")
+    }
+
+    @Test("TC-05: 이중 슬래시 정규화")
+    func encodeDoubleSlash() {
+        #expect(encoder.encode(path: "/Users/bombo/foo//bar") == "-Users-bombo-foo-bar")
+    }
+
+    @Test("TC-06: 루트 경로")
+    func encodeRootPath() {
+        #expect(encoder.encode(path: "/") == "-")
+    }
+
+    @Test("TC-07: 다중 세그먼트")
+    func encodeMultipleSegments() {
+        #expect(encoder.encode(path: "/a/b/c/d/e") == "-a-b-c-d-e")
+    }
+
+    @Test("TC-08: 공백 포함 경로")
+    func encodePathWithSpaces() {
+        #expect(encoder.encode(path: "/Users/bombo/my project") == "-Users-bombo-my project")
+    }
+
+    // MARK: - projectDirectory(for:)
+
+    @Test("TC-09: 기본 경로 조합")
+    func projectDirectoryBasic() throws {
+        let result = try #require(encoder.projectDirectory(for: "/Users/bombo/foo"))
+        #expect(result.path().hasSuffix(".claude/projects/-Users-bombo-foo/"))
+    }
+
+    @Test("TC-10: 정규화 후 조합")
+    func projectDirectoryNormalized() throws {
+        let result = try #require(encoder.projectDirectory(for: "/Users/bombo/../bar"))
+        #expect(result.path().hasSuffix(".claude/projects/-Users-bar/"))
+    }
+
+    @Test("TC-11: 순수 함수 - 동일 입력 동일 출력")
+    func projectDirectoryPureFunction() {
+        let first = encoder.projectDirectory(for: "/Users/bombo/foo")
+        let second = encoder.projectDirectory(for: "/Users/bombo/foo")
+        #expect(first == second)
+    }
+}


### PR DESCRIPTION
## Summary
- SPM 기반 macOS 15.0 / Swift 6.1 프로젝트 구성 (LSUIElement=YES, 샌드박스 비활성화)
- 도메인 모델 정의: `SessionStatus`(5 cases), `SessionInfo`, `ProcessInfo`, `SessionSnapshot` — 전체 Sendable/Hashable 채택
- `PathEncoder`: CWD→encoded path 변환, 경로 정규화(ZT RISK-05 완화), `~/.claude/projects/` 경계 검증

## Audit Summary
| Agent | 판정 |
|-------|------|
| QA | PASS (Minor 1, Info 1) |
| UX | PASS |
| ZT | CONDITIONAL (REC-01~03 반영 완료) |

## Test Results
- `swift build`: 0 errors, 0 warnings
- `swift test`: 11/11 passed (PathEncoder TC-01~TC-11)

## Test plan
- [x] `swift build` 빌드 성공
- [x] `swift test` 11개 테스트 전체 통과
- [x] PathEncoder 경로 정규화 (.., ., //, 후행 슬래시) 검증
- [x] PathEncoder 경계 검증 (projectDirectory → URL? 옵셔널)
- [x] SessionStatus.fileReadError 존재 확인 (ZT GAP-AC06)

Closes #2
Part of Epic #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)