### PR TITLE
feat: Infrastructure 계층 - ProcessScanner + SessionFileReader (#3)

### DIFF
--- a/ClaudeMonitor/Sources/ClaudeMonitor/Infrastructure/NotificationService.swift
+++ b/ClaudeMonitor/Sources/ClaudeMonitor/Infrastructure/NotificationService.swift
@@ -1,0 +1,29 @@
+import UserNotifications
+
+final class NotificationService: Sendable {
+    static let shared = NotificationService()
+
+    func requestPermission() async {
+        _ = try? await UNUserNotificationCenter.current()
+            .requestAuthorization(options: [.alert, .sound])
+    }
+
+    func notify(title: String, body: String) {
+        let center = UNUserNotificationCenter.current()
+        center.getNotificationSettings { settings in
+            guard settings.authorizationStatus == .authorized else { return }
+
+            let content = UNMutableNotificationContent()
+            content.title = title
+            content.body = body
+            content.sound = .default
+
+            let request = UNNotificationRequest(
+                identifier: UUID().uuidString,
+                content: content,
+                trigger: nil
+            )
+            center.add(request)
+        }
+    }
+}

--- a/ClaudeMonitor/Sources/ClaudeMonitor/Infrastructure/ProcessScanner.swift
+++ b/ClaudeMonitor/Sources/ClaudeMonitor/Infrastructure/ProcessScanner.swift
@@ -1,0 +1,126 @@
+import Foundation
+import Darwin
+
+actor ProcessScanner {
+    private var cwdCache: [Int: String] = [:]
+
+    func scan() async -> [ProcessInfo] {
+        let output = runPs()
+        let entries = parsePs(output: output)
+        var results: [ProcessInfo] = []
+        var alivePids: Set<Int> = []
+
+        for entry in entries {
+            alivePids.insert(entry.pid)
+            let cwd = getCwd(pid: entry.pid)
+            results.append(ProcessInfo(pid: entry.pid, tty: entry.tty, cwd: cwd))
+        }
+
+        invalidateCache(alivePids: alivePids)
+        return results
+    }
+
+    struct PsEntry: Sendable {
+        let pid: Int
+        let tty: String
+        let comm: String
+    }
+
+    func parsePs(output: String) -> [PsEntry] {
+        var entries: [PsEntry] = []
+        for line in output.split(separator: "\n") {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            let tokens = trimmed.split(separator: " ", maxSplits: 2)
+            guard tokens.count >= 3 else { continue }
+
+            guard let pid = Int(tokens[0]) else { continue }
+            let tty = String(tokens[1])
+            let comm = String(tokens[2])
+
+            guard tty != "??" else { continue }
+            guard comm.contains("claude") else { continue }
+
+            entries.append(PsEntry(pid: pid, tty: tty, comm: comm))
+        }
+        return entries
+    }
+
+    private func runPs() -> String {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/ps")
+        process.arguments = ["-ax", "-o", "pid=,tty=,comm="]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = FileHandle.nullDevice
+
+        do {
+            try process.run()
+            process.waitUntilExit()
+        } catch {
+            return ""
+        }
+
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        return String(data: data, encoding: .utf8) ?? ""
+    }
+
+    private func getCwd(pid: Int) -> String? {
+        if let cached = cwdCache[pid] { return cached }
+
+        let cwd = procPidCwd(pid: pid) ?? lsofFallback(pid: pid)
+        if let cwd { cwdCache[pid] = cwd }
+        return cwd
+    }
+
+    private func procPidCwd(pid: Int) -> String? {
+        let pathInfoSize = MemoryLayout<proc_vnodepathinfo>.size
+        let pathInfo = UnsafeMutablePointer<proc_vnodepathinfo>.allocate(capacity: 1)
+        defer { pathInfo.deallocate() }
+
+        let result = proc_pidinfo(
+            Int32(pid),
+            PROC_PIDVNODEPATHINFO,
+            0,
+            pathInfo,
+            Int32(pathInfoSize)
+        )
+        guard result == Int32(pathInfoSize) else { return nil }
+
+        return withUnsafePointer(to: &pathInfo.pointee.pvi_cdir.vip_path) { ptr in
+            ptr.withMemoryRebound(to: CChar.self, capacity: Int(MAXPATHLEN)) { cstr in
+                let path = String(cString: cstr)
+                return path.isEmpty ? nil : path
+            }
+        }
+    }
+
+    private func lsofFallback(pid: Int) -> String? {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/sbin/lsof")
+        process.arguments = ["-p", "\(pid)", "-a", "-d", "cwd", "-F", "n"]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = FileHandle.nullDevice
+
+        do {
+            try process.run()
+            process.waitUntilExit()
+        } catch {
+            return nil
+        }
+
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        guard let output = String(data: data, encoding: .utf8) else { return nil }
+
+        for line in output.split(separator: "\n") {
+            if line.hasPrefix("n/") {
+                return String(line.dropFirst(1))
+            }
+        }
+        return nil
+    }
+
+    private func invalidateCache(alivePids: Set<Int>) {
+        cwdCache = cwdCache.filter { alivePids.contains($0.key) }
+    }
+}

--- a/ClaudeMonitor/Sources/ClaudeMonitor/Infrastructure/SessionFileError.swift
+++ b/ClaudeMonitor/Sources/ClaudeMonitor/Infrastructure/SessionFileError.swift
@@ -1,0 +1,6 @@
+enum SessionFileError: Error, Sendable {
+    case noJsonlFile
+    case noAssistantMessage
+    case encodingError
+    case pathViolation
+}

--- a/ClaudeMonitor/Sources/ClaudeMonitor/Infrastructure/SessionFileReader.swift
+++ b/ClaudeMonitor/Sources/ClaudeMonitor/Infrastructure/SessionFileReader.swift
@@ -1,0 +1,136 @@
+import Foundation
+
+actor SessionFileReader {
+    private let claudeProjectsBase: URL
+
+    init(homeDirectory: URL = .homeDirectory) {
+        self.claudeProjectsBase = homeDirectory
+            .appending(path: ".claude/projects", directoryHint: .isDirectory)
+    }
+
+    func readLatestSession(projectDirectory: URL) throws -> SessionSnapshot {
+        let basePath = claudeProjectsBase.standardizedFileURL.path()
+        let basePathWithSlash = basePath.hasSuffix("/") ? basePath : basePath + "/"
+        guard projectDirectory.standardizedFileURL.path()
+            .hasPrefix(basePathWithSlash)
+        else {
+            throw SessionFileError.pathViolation
+        }
+
+        let jsonlFile = try findLatestJsonl(in: projectDirectory)
+        let tailText = try tailRead(file: jsonlFile)
+        return try parseLastAssistantMessage(from: tailText, fileURL: jsonlFile)
+    }
+
+    func findLatestJsonl(in directory: URL) throws -> URL {
+        let fm = FileManager.default
+        let contents: [URL]
+        do {
+            contents = try fm.contentsOfDirectory(
+                at: directory,
+                includingPropertiesForKeys: [.contentModificationDateKey],
+                options: [.skipsHiddenFiles, .skipsSubdirectoryDescendants]
+            )
+        } catch {
+            throw SessionFileError.noJsonlFile
+        }
+
+        let jsonlFiles = contents
+            .filter { $0.pathExtension == "jsonl" }
+            .filter { !$0.path().contains("/subagents/") }
+
+        guard !jsonlFiles.isEmpty else {
+            throw SessionFileError.noJsonlFile
+        }
+
+        let sorted = jsonlFiles.sorted { a, b in
+            let dateA = (try? a.resourceValues(forKeys: [.contentModificationDateKey]))?.contentModificationDate ?? .distantPast
+            let dateB = (try? b.resourceValues(forKeys: [.contentModificationDateKey]))?.contentModificationDate ?? .distantPast
+            return dateA > dateB
+        }
+
+        return sorted[0]
+    }
+
+    private func tailRead(file: URL) throws -> String {
+        let handle: FileHandle
+        do {
+            handle = try FileHandle(forReadingFrom: file)
+        } catch {
+            throw SessionFileError.noJsonlFile
+        }
+        defer { try? handle.close() }
+
+        let fileSize: UInt64
+        do {
+            fileSize = try handle.seekToEnd()
+        } catch {
+            throw SessionFileError.noJsonlFile
+        }
+
+        guard fileSize > 0 else {
+            throw SessionFileError.noAssistantMessage
+        }
+
+        let readSize = min(fileSize, 16 * 1024)
+        try handle.seek(toOffset: fileSize - readSize)
+
+        let data = handle.readData(ofLength: Int(readSize))
+        guard let text = String(data: data, encoding: .utf8) else {
+            throw SessionFileError.encodingError
+        }
+        return text
+    }
+
+    private func parseLastAssistantMessage(from text: String, fileURL: URL) throws -> SessionSnapshot {
+        let lines = text.split(separator: "\n").reversed()
+
+        var sessionId: String?
+        var gitBranch: String?
+
+        for line in lines {
+            guard let jsonData = line.data(using: .utf8),
+                  let json = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any]
+            else { continue }
+
+            if sessionId == nil, let sid = json["sessionId"] as? String {
+                sessionId = sid
+            }
+            if gitBranch == nil, let branch = json["gitBranch"] as? String {
+                gitBranch = branch
+            }
+
+            guard json["type"] as? String == "assistant",
+                  let message = json["message"] as? [String: Any],
+                  message["role"] as? String == "assistant"
+            else { continue }
+
+            let lastAssistantText: String
+            if let content = message["content"] as? [[String: Any]] {
+                let texts = content
+                    .filter { $0["type"] as? String == "text" }
+                    .compactMap { $0["text"] as? String }
+                lastAssistantText = String(texts.joined(separator: " ").prefix(100))
+            } else {
+                lastAssistantText = ""
+            }
+
+            let stopReason = json["stop_reason"] as? String
+                ?? (message["stop_reason"] as? String)
+            let hasError = (stopReason != nil) && (stopReason != "end_turn")
+
+            let attrs = try? FileManager.default.attributesOfItem(atPath: fileURL.path())
+            let lastModified = (attrs?[.modificationDate] as? Date) ?? Date()
+
+            return SessionSnapshot(
+                sessionId: sessionId ?? "unknown",
+                gitBranch: gitBranch ?? "unknown",
+                lastAssistantText: lastAssistantText,
+                lastModified: lastModified,
+                hasError: hasError
+            )
+        }
+
+        throw SessionFileError.noAssistantMessage
+    }
+}

--- a/ClaudeMonitor/Tests/ClaudeMonitorTests/ProcessScannerTests.swift
+++ b/ClaudeMonitor/Tests/ClaudeMonitorTests/ProcessScannerTests.swift
@@ -1,0 +1,83 @@
+import Testing
+@testable import ClaudeMonitor
+
+@Suite("ProcessScanner Tests")
+struct ProcessScannerTests {
+
+    // TC-01: scan() returns results (may be empty if no claude running)
+    @Test("scan returns ProcessInfo array")
+    func scanReturnsArray() async {
+        let scanner = ProcessScanner()
+        let results = await scanner.scan()
+        // Can't guarantee claude is running, just verify it doesn't crash
+        #expect(results is [ProcessInfo])
+    }
+
+    // TC-02: TTY ?? excluded
+    @Test("parsePs excludes TTY ??")
+    func parsePsExcludesDaemon() async {
+        let output = """
+        1234 s004 /usr/local/bin/claude
+        5678 ??   /usr/local/bin/claude
+        9012 s005 /usr/local/bin/node
+        """
+        let scanner = ProcessScanner()
+        let entries = await scanner.parsePs(output: output)
+        #expect(entries.count == 1)
+        #expect(entries[0].pid == 1234)
+        #expect(entries[0].tty == "s004")
+    }
+
+    // TC-03: Only claude processes matched
+    @Test("parsePs filters claude only")
+    func parsePsFiltersClaude() async {
+        let output = """
+        1111 s001 /usr/bin/vim
+        2222 s002 /usr/local/bin/claude
+        3333 s003 /usr/bin/node
+        """
+        let scanner = ProcessScanner()
+        let entries = await scanner.parsePs(output: output)
+        #expect(entries.count == 1)
+        #expect(entries[0].pid == 2222)
+    }
+
+    // TC-05: Normal ps output parsing
+    @Test("parsePs parses well-formed output")
+    func parsePsNormal() async {
+        let output = """
+        12345 s004 /opt/homebrew/bin/claude
+        67890 s005 /opt/homebrew/bin/claude
+        """
+        let scanner = ProcessScanner()
+        let entries = await scanner.parsePs(output: output)
+        #expect(entries.count == 2)
+        #expect(entries[0].pid == 12345)
+        #expect(entries[0].tty == "s004")
+        #expect(entries[1].pid == 67890)
+        #expect(entries[1].tty == "s005")
+    }
+
+    // TC-06: Empty output
+    @Test("parsePs handles empty output")
+    func parsePsEmpty() async {
+        let scanner = ProcessScanner()
+        let entries = await scanner.parsePs(output: "")
+        #expect(entries.isEmpty)
+    }
+
+    // TC: Malformed lines skipped
+    @Test("parsePs skips malformed lines")
+    func parsePsMalformed() async {
+        let output = """
+        notanumber s004 claude
+        1234
+
+        5678 s005 /usr/local/bin/claude
+        """
+        let scanner = ProcessScanner()
+        let entries = await scanner.parsePs(output: output)
+        #expect(entries.count == 1)
+        #expect(entries[0].pid == 5678)
+    }
+}

--- a/ClaudeMonitor/Tests/ClaudeMonitorTests/SessionFileReaderTests.swift
+++ b/ClaudeMonitor/Tests/ClaudeMonitorTests/SessionFileReaderTests.swift
@@ -1,0 +1,186 @@
+import Testing
+import Foundation
+@testable import ClaudeMonitor
+
+@Suite("SessionFileReader Tests")
+struct SessionFileReaderTests {
+
+    private func createTempDir() throws -> URL {
+        let tmpDir = FileManager.default.temporaryDirectory
+            .appending(path: UUID().uuidString, directoryHint: .isDirectory)
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        return tmpDir
+    }
+
+    private func createReaderWithBase(_ baseDir: URL) -> SessionFileReader {
+        // baseDir = <home>/.claude/projects/
+        // 2단계 역산: projects → .claude → home
+        let home = baseDir
+            .deletingLastPathComponent() // .claude
+            .deletingLastPathComponent() // home
+        return SessionFileReader(homeDirectory: home)
+    }
+
+    private func setupProjectDir() throws -> (projectDir: URL, reader: SessionFileReader) {
+        let tmpDir = try createTempDir()
+        let claudeProjects = tmpDir.appending(path: ".claude/projects/test-project", directoryHint: .isDirectory)
+        try FileManager.default.createDirectory(at: claudeProjects, withIntermediateDirectories: true)
+        let reader = createReaderWithBase(
+            tmpDir.appending(path: ".claude/projects", directoryHint: .isDirectory)
+        )
+        return (claudeProjects, reader)
+    }
+
+    private let normalJsonl = """
+    {"type":"system","sessionId":"abc-123","gitBranch":"main","cwd":"/tmp"}
+    {"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Hello, I can help you with that task."}]},"stop_reason":"end_turn","sessionId":"abc-123","gitBranch":"main"}
+    """
+
+    // TC-07: Normal JSONL parsing
+    @Test("reads latest session from valid JSONL")
+    func readNormalJsonl() async throws {
+        let (projectDir, reader) = try setupProjectDir()
+        let file = projectDir.appending(path: "session1.jsonl")
+        try normalJsonl.write(to: file, atomically: true, encoding: .utf8)
+
+        let snapshot = try await reader.readLatestSession(projectDirectory: projectDir)
+        #expect(snapshot.sessionId == "abc-123")
+        #expect(snapshot.gitBranch == "main")
+        #expect(snapshot.lastAssistantText == "Hello, I can help you with that task.")
+        #expect(snapshot.hasError == false)
+    }
+
+    // TC-08: No assistant message
+    @Test("throws noAssistantMessage when no assistant lines")
+    func noAssistantMessage() async throws {
+        let (projectDir, reader) = try setupProjectDir()
+        let file = projectDir.appending(path: "session1.jsonl")
+        let content = """
+        {"type":"system","sessionId":"abc-123","gitBranch":"main"}
+        {"type":"user","message":{"role":"user","content":"hello"}}
+        """
+        try content.write(to: file, atomically: true, encoding: .utf8)
+
+        await #expect(throws: SessionFileError.noAssistantMessage) {
+            try await reader.readLatestSession(projectDirectory: projectDir)
+        }
+    }
+
+    // TC-09: Empty directory
+    @Test("throws noJsonlFile for empty directory")
+    func emptyDirectory() async throws {
+        let (projectDir, reader) = try setupProjectDir()
+
+        await #expect(throws: SessionFileError.noJsonlFile) {
+            try await reader.readLatestSession(projectDirectory: projectDir)
+        }
+    }
+
+    // TC-10: prefix(100) applied
+    @Test("lastAssistantText truncated to 100 chars")
+    func prefixTruncation() async throws {
+        let (projectDir, reader) = try setupProjectDir()
+        let longText = String(repeating: "a", count: 200)
+        let content = """
+        {"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"\(longText)"}]},"stop_reason":"end_turn","sessionId":"s1","gitBranch":"main"}
+        """
+        let file = projectDir.appending(path: "session1.jsonl")
+        try content.write(to: file, atomically: true, encoding: .utf8)
+
+        let snapshot = try await reader.readLatestSession(projectDirectory: projectDir)
+        #expect(snapshot.lastAssistantText.count == 100)
+    }
+
+    // TC-11: stop_reason != end_turn → hasError
+    @Test("hasError true when stop_reason is not end_turn")
+    func hasErrorOnNonEndTurn() async throws {
+        let (projectDir, reader) = try setupProjectDir()
+        let content = """
+        {"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"partial"}]},"stop_reason":"max_tokens","sessionId":"s1","gitBranch":"main"}
+        """
+        let file = projectDir.appending(path: "session1.jsonl")
+        try content.write(to: file, atomically: true, encoding: .utf8)
+
+        let snapshot = try await reader.readLatestSession(projectDirectory: projectDir)
+        #expect(snapshot.hasError == true)
+    }
+
+    // TC: stop_reason nil (streaming/in-progress) → hasError false
+    @Test("hasError false when stop_reason is nil")
+    func hasErrorFalseWhenStopReasonNil() async throws {
+        let (projectDir, reader) = try setupProjectDir()
+        let content = """
+        {"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"still working"}]},"sessionId":"s1","gitBranch":"main"}
+        """
+        let file = projectDir.appending(path: "session1.jsonl")
+        try content.write(to: file, atomically: true, encoding: .utf8)
+
+        let snapshot = try await reader.readLatestSession(projectDirectory: projectDir)
+        #expect(snapshot.hasError == false)
+    }
+
+    // TC-12: thinking content excluded
+    @Test("excludes thinking content blocks")
+    func excludeThinking() async throws {
+        let (projectDir, reader) = try setupProjectDir()
+        let content = """
+        {"type":"assistant","message":{"role":"assistant","content":[{"type":"thinking","thinking":"internal thought"},{"type":"text","text":"visible response"}]},"stop_reason":"end_turn","sessionId":"s1","gitBranch":"main"}
+        """
+        let file = projectDir.appending(path: "session1.jsonl")
+        try content.write(to: file, atomically: true, encoding: .utf8)
+
+        let snapshot = try await reader.readLatestSession(projectDirectory: projectDir)
+        #expect(snapshot.lastAssistantText == "visible response")
+        #expect(!snapshot.lastAssistantText.contains("internal thought"))
+    }
+
+    // TC-13: Path violation
+    @Test("throws pathViolation for directory outside claudeProjectsBase")
+    func pathViolation() async throws {
+        let tmpDir = try createTempDir()
+        let reader = SessionFileReader(homeDirectory: tmpDir)
+        let outsideDir = FileManager.default.temporaryDirectory
+            .appending(path: "outside-\(UUID().uuidString)", directoryHint: .isDirectory)
+        try FileManager.default.createDirectory(at: outsideDir, withIntermediateDirectories: true)
+
+        await #expect(throws: SessionFileError.pathViolation) {
+            try await reader.readLatestSession(projectDirectory: outsideDir)
+        }
+    }
+
+    // TC-14: subagents/ directory excluded
+    @Test("findLatestJsonl excludes subagents directory")
+    func excludeSubagents() async throws {
+        let (projectDir, reader) = try setupProjectDir()
+
+        // Create a jsonl in subagents/ (should be ignored)
+        let subagentsDir = projectDir.appending(path: "subagents", directoryHint: .isDirectory)
+        try FileManager.default.createDirectory(at: subagentsDir, withIntermediateDirectories: true)
+        try "{}".write(to: subagentsDir.appending(path: "sub.jsonl"), atomically: true, encoding: .utf8)
+
+        // Create a valid jsonl at root level
+        let file = projectDir.appending(path: "session1.jsonl")
+        try normalJsonl.write(to: file, atomically: true, encoding: .utf8)
+
+        let latest = try await reader.findLatestJsonl(in: projectDir)
+        #expect(latest.lastPathComponent == "session1.jsonl")
+    }
+
+    // TC-15: findLatestJsonl picks most recent
+    @Test("findLatestJsonl returns most recently modified file")
+    func latestByModificationDate() async throws {
+        let (projectDir, reader) = try setupProjectDir()
+
+        let file1 = projectDir.appending(path: "old.jsonl")
+        try "{}".write(to: file1, atomically: true, encoding: .utf8)
+
+        // Small delay to ensure different modification times
+        try await Task.sleep(for: .milliseconds(50))
+
+        let file2 = projectDir.appending(path: "new.jsonl")
+        try normalJsonl.write(to: file2, atomically: true, encoding: .utf8)
+
+        let latest = try await reader.findLatestJsonl(in: projectDir)
+        #expect(latest.lastPathComponent == "new.jsonl")
+    }
+}


### PR DESCRIPTION
## Summary
- **ProcessScanner** actor: `ps -ax` + `proc_pidinfo` CWD 획득 + `lsof` fallback + PID 캐싱
- **SessionFileReader** actor: JSONL tail read (16KB) + assistant 메시지 파싱 + 경로 경계 검증
- **SessionFileError** enum: 4 cases (noJsonlFile, noAssistantMessage, encodingError, pathViolation)
- **NotificationService**: `UNUserNotificationCenter` 래퍼, 권한 거부 시 무시

## Test plan
- [x] ProcessScanner ps 출력 파싱 (TTY 필터, claude 필터, 빈 출력, 잘못된 행)
- [x] ProcessScanner 실제 환경 scan() 크래시 없음
- [x] SessionFileReader 정상 JSONL 파싱 → SessionSnapshot
- [x] SessionFileReader assistant 메시지 없음 → throw
- [x] SessionFileReader 빈 디렉토리 → throw
- [x] SessionFileReader prefix(100) 적용
- [x] SessionFileReader stop_reason != end_turn → hasError
- [x] SessionFileReader stop_reason nil → hasError false
- [x] SessionFileReader thinking content 제외
- [x] SessionFileReader 경로 검증 (pathViolation)
- [x] SessionFileReader subagents/ 제외
- [x] SessionFileReader 최신 파일 선택

**27/27 tests passed** (기존 11 + 신규 16)

## Audit Summary
- **QA**: PASS — Critical 0, Major 0, Minor 5
- **UX**: PASS — stop_reason nil 오분류 수정 완료
- **ZT**: CONDITIONAL→SECURE — 경로 접두사 trailing slash 수정 완료

Closes #3
Part of Epic #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)