### PR TITLE
feat: Domain 계층 - SessionStateManager Actor (#4)

### DIFF
--- a/ClaudeMonitor/Sources/ClaudeMonitor/App/ClaudeMonitorApp.swift
+++ b/ClaudeMonitor/Sources/ClaudeMonitor/App/ClaudeMonitorApp.swift
@@ -2,9 +2,24 @@ import SwiftUI
 
 @main
 struct ClaudeMonitorApp: App {
+    @State private var sessionStore: SessionStore
+    @State private var manager: SessionStateManager
+
     var body: some Scene {
         Settings {
             EmptyView()
+        }
+    }
+
+    init() {
+        let store = SessionStore()
+        let mgr = SessionStateManager(store: store)
+        _sessionStore = State(initialValue: store)
+        _manager = State(initialValue: mgr)
+
+        Task {
+            await NotificationService.shared.requestPermission()
+            await mgr.start()
         }
     }
 }

--- a/ClaudeMonitor/Sources/ClaudeMonitor/Domain/Models/SessionInfo.swift
+++ b/ClaudeMonitor/Sources/ClaudeMonitor/Domain/Models/SessionInfo.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct ProcessInfo: Sendable, Hashable {
+struct ClaudeProcessInfo: Sendable, Hashable {
     let pid: Int
     let tty: String
     let cwd: String?

--- a/ClaudeMonitor/Sources/ClaudeMonitor/Domain/PendingRemoval.swift
+++ b/ClaudeMonitor/Sources/ClaudeMonitor/Domain/PendingRemoval.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+struct PendingRemoval: Sendable {
+    let sessionId: String
+    let removeAfter: Date
+}

--- a/ClaudeMonitor/Sources/ClaudeMonitor/Domain/Protocols.swift
+++ b/ClaudeMonitor/Sources/ClaudeMonitor/Domain/Protocols.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+protocol ProcessScannerProtocol: Actor {
+    func scan() async -> [ClaudeProcessInfo]
+}
+
+protocol SessionFileReaderProtocol: Actor {
+    func readLatestSession(projectDirectory: URL) throws -> SessionSnapshot
+}
+
+protocol NotificationServiceProtocol: Sendable {
+    func notify(title: String, body: String)
+}

--- a/ClaudeMonitor/Sources/ClaudeMonitor/Domain/SessionStateManager.swift
+++ b/ClaudeMonitor/Sources/ClaudeMonitor/Domain/SessionStateManager.swift
@@ -1,0 +1,317 @@
+import Foundation
+
+actor SessionStateManager {
+
+    private struct ManagedSession: Sendable {
+        var info: SessionInfo
+        let processInfo: ClaudeProcessInfo
+        var enteredCurrentStatusAt: Date
+        var hasError: Bool = false
+    }
+
+    private let sessionStore: SessionStore
+    private let processScanner: any ProcessScannerProtocol
+    private let fileReader: any SessionFileReaderProtocol
+    private let notificationService: any NotificationServiceProtocol
+    private let pathEncoder: PathEncoder
+    private let clock: @Sendable () -> Date
+    private let processInterval: Duration
+    private let fileInterval: Duration
+    private let idleThreshold: TimeInterval
+
+    private var managed: [String: ManagedSession] = [:]
+    private var pendingRemovals: [PendingRemoval] = []
+    private var previousPids: Set<Int> = []
+    private var pidToSessionId: [Int: String] = [:]
+    private var processTask: Task<Void, Never>?
+    private var fileTask: Task<Void, Never>?
+
+    init(
+        store: SessionStore,
+        processScanner: any ProcessScannerProtocol = ProcessScanner(),
+        fileReader: any SessionFileReaderProtocol = SessionFileReader(),
+        notificationService: any NotificationServiceProtocol = NotificationService.shared,
+        pathEncoder: PathEncoder = PathEncoder(),
+        clock: @escaping @Sendable () -> Date = { Date() },
+        processInterval: Duration = .seconds(10),
+        fileInterval: Duration = .seconds(30),
+        idleThreshold: TimeInterval = 5 * 60
+    ) {
+        self.sessionStore = store
+        self.processScanner = processScanner
+        self.fileReader = fileReader
+        self.notificationService = notificationService
+        self.pathEncoder = pathEncoder
+        self.clock = clock
+        self.processInterval = processInterval
+        self.fileInterval = fileInterval
+        self.idleThreshold = idleThreshold
+    }
+
+    deinit {
+        processTask?.cancel()
+        fileTask?.cancel()
+    }
+
+    func start() {
+        guard processTask == nil else { return }
+
+        processTask = Task { [weak self] in
+            guard let self else { return }
+            while !Task.isCancelled {
+                await self.pollProcessesOnce()
+                try? await Task.sleep(for: self.processInterval)
+            }
+        }
+
+        fileTask = Task { [weak self] in
+            guard let self else { return }
+            while !Task.isCancelled {
+                await self.pollFilesOnce()
+                try? await Task.sleep(for: self.fileInterval)
+            }
+        }
+    }
+
+    func stop() {
+        processTask?.cancel()
+        processTask = nil
+        fileTask?.cancel()
+        fileTask = nil
+    }
+
+    // MARK: - Process Polling
+
+    func pollProcessesOnce() async {
+        let processes = await processScanner.scan()
+        let currentPids = Set(processes.map(\.pid))
+
+        // Detect new PIDs
+        for proc in processes where !previousPids.contains(proc.pid) {
+            addSession(from: proc)
+        }
+
+        // Detect terminated PIDs
+        let terminatedPids = previousPids.subtracting(currentPids)
+        for pid in terminatedPids {
+            markTerminated(pid: pid)
+        }
+
+        // Check idle transitions
+        checkIdleTransitions(alivePids: currentPids)
+
+        // Process pending removals
+        processPendingRemovals()
+
+        previousPids = currentPids
+        await pushToStore()
+    }
+
+    // MARK: - File Polling
+
+    func pollFilesOnce() async {
+        let now = clock()
+
+        for (sessionId, session) in managed {
+            guard let cwd = session.processInfo.cwd,
+                  let projectDir = pathEncoder.projectDirectory(for: cwd)
+            else { continue }
+
+            // Skip completed/error sessions
+            switch session.info.status {
+            case .completed, .error:
+                continue
+            default:
+                break
+            }
+
+            do {
+                let snapshot = try await fileReader.readLatestSession(projectDirectory: projectDir)
+                updateFromSnapshot(sessionId: sessionId, snapshot: snapshot, now: now)
+            } catch {
+                markFileReadError(sessionId: sessionId, now: now)
+            }
+        }
+
+        await pushToStore()
+    }
+
+    // MARK: - Session Management
+
+    private func addSession(from proc: ClaudeProcessInfo) {
+        guard let cwd = proc.cwd else { return }
+
+        let now = clock()
+        let projectName = URL(fileURLWithPath: cwd).lastPathComponent
+        let sessionId = "\(proc.pid)-\(proc.tty)"
+
+        let info = SessionInfo(
+            id: sessionId,
+            pid: proc.pid,
+            tty: proc.tty,
+            projectName: projectName,
+            projectPath: URL(fileURLWithPath: cwd),
+            gitBranch: "unknown",
+            lastAssistantText: "",
+            status: .running,
+            lastUpdated: now
+        )
+
+        managed[sessionId] = ManagedSession(
+            info: info,
+            processInfo: proc,
+            enteredCurrentStatusAt: now
+        )
+        pidToSessionId[proc.pid] = sessionId
+    }
+
+    private func markTerminated(pid: Int) {
+        guard let sessionId = pidToSessionId[pid],
+              var session = managed[sessionId]
+        else { return }
+
+        let now = clock()
+
+        if session.hasError {
+            session.info = rebuildInfo(session.info, status: .error, lastUpdated: now)
+            pendingRemovals.append(PendingRemoval(sessionId: sessionId, removeAfter: now.addingTimeInterval(60)))
+            notificationService.notify(
+                title: session.info.projectName,
+                body: "Session error"
+            )
+        } else {
+            session.info = rebuildInfo(session.info, status: .completed, lastUpdated: now)
+            pendingRemovals.append(PendingRemoval(sessionId: sessionId, removeAfter: now.addingTimeInterval(30)))
+            notificationService.notify(
+                title: session.info.projectName,
+                body: "Session completed"
+            )
+        }
+
+        session.enteredCurrentStatusAt = now
+        managed[sessionId] = session
+        pidToSessionId.removeValue(forKey: pid)
+    }
+
+    private func updateFromSnapshot(sessionId: String, snapshot: SessionSnapshot, now: Date) {
+        guard var session = managed[sessionId] else { return }
+
+        let newStatus: SessionStatus
+        if session.info.status == .idle && snapshot.lastModified > session.enteredCurrentStatusAt {
+            newStatus = .running
+        } else if session.info.status == .fileReadError {
+            newStatus = .running
+        } else {
+            newStatus = session.info.status
+        }
+
+        let statusChanged = newStatus != session.info.status
+
+        session.info = SessionInfo(
+            id: session.info.id,
+            pid: session.info.pid,
+            tty: session.info.tty,
+            projectName: session.info.projectName,
+            projectPath: session.info.projectPath,
+            gitBranch: snapshot.gitBranch,
+            lastAssistantText: snapshot.lastAssistantText,
+            status: newStatus,
+            lastUpdated: now
+        )
+
+        session.hasError = snapshot.hasError
+
+        if statusChanged {
+            session.enteredCurrentStatusAt = now
+        }
+
+        managed[sessionId] = session
+    }
+
+    private func markFileReadError(sessionId: String, now: Date) {
+        guard var session = managed[sessionId] else { return }
+
+        // Only transition to fileReadError from running or idle
+        switch session.info.status {
+        case .running, .idle:
+            session.info = rebuildInfo(session.info, status: .fileReadError, lastUpdated: now)
+            session.enteredCurrentStatusAt = now
+            managed[sessionId] = session
+        default:
+            break
+        }
+    }
+
+    private func checkIdleTransitions(alivePids: Set<Int>) {
+        let now = clock()
+
+        for (sessionId, var session) in managed {
+            guard alivePids.contains(session.info.pid) else { continue }
+
+            if session.info.status == .running {
+                let elapsed = now.timeIntervalSince(session.info.lastUpdated)
+                if elapsed > idleThreshold {
+                    session.info = rebuildInfo(session.info, status: .idle, lastUpdated: now)
+                    session.enteredCurrentStatusAt = now
+                    managed[sessionId] = session
+                }
+            }
+        }
+    }
+
+    private func processPendingRemovals() {
+        let now = clock()
+        var remainingRemovals: [PendingRemoval] = []
+
+        for removal in pendingRemovals {
+            if removal.removeAfter <= now {
+                if let session = managed[removal.sessionId] {
+                    pidToSessionId.removeValue(forKey: session.info.pid)
+                }
+                managed.removeValue(forKey: removal.sessionId)
+            } else {
+                remainingRemovals.append(removal)
+            }
+        }
+
+        pendingRemovals = remainingRemovals
+    }
+
+    // MARK: - SwiftUI Push
+
+    private func pushToStore() async {
+        let sortedSessions = managed.values
+            .map(\.info)
+            .sorted { $0.lastUpdated > $1.lastUpdated }
+
+        await MainActor.run {
+            sessionStore.sessions = sortedSessions
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func rebuildInfo(_ info: SessionInfo, status: SessionStatus, lastUpdated: Date) -> SessionInfo {
+        SessionInfo(
+            id: info.id,
+            pid: info.pid,
+            tty: info.tty,
+            projectName: info.projectName,
+            projectPath: info.projectPath,
+            gitBranch: info.gitBranch,
+            lastAssistantText: info.lastAssistantText,
+            status: status,
+            lastUpdated: lastUpdated
+        )
+    }
+
+    // MARK: - Test Helpers
+
+    var currentSessions: [SessionInfo] {
+        managed.values.map(\.info).sorted { $0.lastUpdated > $1.lastUpdated }
+    }
+
+    var pendingRemovalCount: Int {
+        pendingRemovals.count
+    }
+}

--- a/ClaudeMonitor/Sources/ClaudeMonitor/Domain/SessionStore.swift
+++ b/ClaudeMonitor/Sources/ClaudeMonitor/Domain/SessionStore.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+@MainActor
+@Observable
+final class SessionStore {
+    var sessions: [SessionInfo] = []
+}

--- a/ClaudeMonitor/Sources/ClaudeMonitor/Infrastructure/NotificationService.swift
+++ b/ClaudeMonitor/Sources/ClaudeMonitor/Infrastructure/NotificationService.swift
@@ -1,6 +1,6 @@
 import UserNotifications
 
-final class NotificationService: Sendable {
+final class NotificationService: NotificationServiceProtocol, Sendable {
     static let shared = NotificationService()
 
     func requestPermission() async {

--- a/ClaudeMonitor/Sources/ClaudeMonitor/Infrastructure/ProcessScanner.swift
+++ b/ClaudeMonitor/Sources/ClaudeMonitor/Infrastructure/ProcessScanner.swift
@@ -1,19 +1,19 @@
 import Foundation
 import Darwin
 
-actor ProcessScanner {
+actor ProcessScanner: ProcessScannerProtocol {
     private var cwdCache: [Int: String] = [:]
 
-    func scan() async -> [ProcessInfo] {
+    func scan() async -> [ClaudeProcessInfo] {
         let output = runPs()
         let entries = parsePs(output: output)
-        var results: [ProcessInfo] = []
+        var results: [ClaudeProcessInfo] = []
         var alivePids: Set<Int> = []
 
         for entry in entries {
             alivePids.insert(entry.pid)
             let cwd = getCwd(pid: entry.pid)
-            results.append(ProcessInfo(pid: entry.pid, tty: entry.tty, cwd: cwd))
+            results.append(ClaudeProcessInfo(pid: entry.pid, tty: entry.tty, cwd: cwd))
         }
 
         invalidateCache(alivePids: alivePids)

--- a/ClaudeMonitor/Sources/ClaudeMonitor/Infrastructure/SessionFileReader.swift
+++ b/ClaudeMonitor/Sources/ClaudeMonitor/Infrastructure/SessionFileReader.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-actor SessionFileReader {
+actor SessionFileReader: SessionFileReaderProtocol {
     private let claudeProjectsBase: URL
 
     init(homeDirectory: URL = .homeDirectory) {

--- a/ClaudeMonitor/Tests/ClaudeMonitorTests/ProcessScannerTests.swift
+++ b/ClaudeMonitor/Tests/ClaudeMonitorTests/ProcessScannerTests.swift
@@ -10,7 +10,7 @@ struct ProcessScannerTests {
         let scanner = ProcessScanner()
         let results = await scanner.scan()
         // Can't guarantee claude is running, just verify it doesn't crash
-        #expect(results is [ProcessInfo])
+        #expect(results is [ClaudeProcessInfo])
     }
 
     // TC-02: TTY ?? excluded

--- a/ClaudeMonitor/Tests/ClaudeMonitorTests/SessionStateManagerTests.swift
+++ b/ClaudeMonitor/Tests/ClaudeMonitorTests/SessionStateManagerTests.swift
@@ -1,0 +1,435 @@
+import Testing
+import Foundation
+@testable import ClaudeMonitor
+
+// MARK: - Mock Actors
+
+actor MockProcessScanner: ProcessScannerProtocol {
+    var scanResults: [[ClaudeProcessInfo]] = []
+    private var callIndex = 0
+
+    func setScanResults(_ results: [[ClaudeProcessInfo]]) {
+        self.scanResults = results
+        self.callIndex = 0
+    }
+
+    func scan() async -> [ClaudeProcessInfo] {
+        guard callIndex < scanResults.count else { return [] }
+        let result = scanResults[callIndex]
+        callIndex += 1
+        return result
+    }
+}
+
+actor MockSessionFileReader: SessionFileReaderProtocol {
+    var results: [String: Result<SessionSnapshot, Error>] = [:]
+    var defaultSnapshot: SessionSnapshot?
+
+    func setResult(for directory: URL, result: Result<SessionSnapshot, Error>) {
+        results[directory.path()] = result
+    }
+
+    func setDefaultSnapshot(_ snapshot: SessionSnapshot) {
+        defaultSnapshot = snapshot
+    }
+
+    func readLatestSession(projectDirectory: URL) throws -> SessionSnapshot {
+        if let result = results[projectDirectory.path()] {
+            return try result.get()
+        }
+        if let snapshot = defaultSnapshot {
+            return snapshot
+        }
+        throw SessionFileError.noJsonlFile
+    }
+}
+
+final class MockNotificationService: NotificationServiceProtocol, @unchecked Sendable {
+    private let lock = NSLock()
+    private var _notifications: [(title: String, body: String)] = []
+
+    func notify(title: String, body: String) {
+        lock.lock()
+        _notifications.append((title: title, body: body))
+        lock.unlock()
+    }
+
+    func getNotifications() -> [(title: String, body: String)] {
+        lock.lock()
+        defer { lock.unlock() }
+        return _notifications
+    }
+}
+
+// Thread-safe mutable clock for tests
+final class TestClock: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _now: Date
+
+    init(_ date: Date = Date()) {
+        self._now = date
+    }
+
+    var now: Date {
+        lock.lock()
+        defer { lock.unlock() }
+        return _now
+    }
+
+    func advance(by interval: TimeInterval) {
+        lock.lock()
+        _now = _now.addingTimeInterval(interval)
+        lock.unlock()
+    }
+}
+
+// MARK: - Tests
+
+@Suite("SessionStateManager Tests")
+struct SessionStateManagerTests {
+
+    private func makePathEncoder() -> PathEncoder {
+        PathEncoder(homeDirectory: URL(fileURLWithPath: "/tmp/test-home"))
+    }
+
+    private func makeSut(
+        scanner: MockProcessScanner = MockProcessScanner(),
+        fileReader: MockSessionFileReader = MockSessionFileReader(),
+        notificationService: MockNotificationService = MockNotificationService(),
+        testClock: TestClock = TestClock(),
+        idleThreshold: TimeInterval = 5 * 60
+    ) async -> (SessionStateManager, SessionStore, MockProcessScanner, MockSessionFileReader, MockNotificationService) {
+        let store = await SessionStore()
+        let clock = testClock
+        let manager = SessionStateManager(
+            store: store,
+            processScanner: scanner,
+            fileReader: fileReader,
+            notificationService: notificationService,
+            pathEncoder: makePathEncoder(),
+            clock: { clock.now },
+            idleThreshold: idleThreshold
+        )
+        return (manager, store, scanner, fileReader, notificationService)
+    }
+
+    private func makeProc(pid: Int = 1234, tty: String = "s004", cwd: String? = "/Users/test/project") -> ClaudeProcessInfo {
+        ClaudeProcessInfo(pid: pid, tty: tty, cwd: cwd)
+    }
+
+    private func makeSnapshot(
+        sessionId: String = "test-session",
+        gitBranch: String = "main",
+        lastAssistantText: String = "Working on task",
+        lastModified: Date = Date(),
+        hasError: Bool = false
+    ) -> SessionSnapshot {
+        SessionSnapshot(
+            sessionId: sessionId,
+            gitBranch: gitBranch,
+            lastAssistantText: lastAssistantText,
+            lastModified: lastModified,
+            hasError: hasError
+        )
+    }
+
+    // TC-SSM-01: New PID detected → session added
+    @Test("New PID detected adds session")
+    func newPidAddsSession() async {
+        let scanner = MockProcessScanner()
+        let (manager, store, _, _, _) = await makeSut(scanner: scanner)
+
+        await scanner.setScanResults([[makeProc()]])
+        await manager.pollProcessesOnce()
+
+        let sessions = await store.sessions
+        #expect(sessions.count == 1)
+        #expect(sessions[0].pid == 1234)
+        #expect(sessions[0].projectName == "project")
+        #expect(sessions[0].status == .running)
+    }
+
+    // TC-SSM-03: PID terminated + no error → completed + notification
+    @Test("PID terminated without error marks completed and notifies")
+    func pidTerminatedNoError() async {
+        let scanner = MockProcessScanner()
+        let notifService = MockNotificationService()
+        let (manager, store, _, _, _) = await makeSut(scanner: scanner, notificationService: notifService)
+
+        await scanner.setScanResults([
+            [makeProc()],
+            []
+        ])
+
+        await manager.pollProcessesOnce()
+        await manager.pollProcessesOnce()
+
+        let sessions = await store.sessions
+        #expect(sessions.count == 1)
+        #expect(sessions[0].status == .completed)
+
+        let notifications = notifService.getNotifications()
+        #expect(notifications.count == 1)
+        #expect(notifications[0].body == "Session completed")
+    }
+
+    // TC-SSM-04: PID terminated + hasError → error + notification
+    @Test("PID terminated with error marks error and notifies")
+    func pidTerminatedWithError() async {
+        let scanner = MockProcessScanner()
+        let fileReader = MockSessionFileReader()
+        let notifService = MockNotificationService()
+        let (manager, store, _, _, _) = await makeSut(
+            scanner: scanner, fileReader: fileReader, notificationService: notifService
+        )
+
+        let proc = makeProc()
+        await scanner.setScanResults([[proc], []])
+
+        let pathEncoder = makePathEncoder()
+        if let projectDir = pathEncoder.projectDirectory(for: proc.cwd!) {
+            await fileReader.setResult(
+                for: projectDir,
+                result: .success(makeSnapshot(hasError: true))
+            )
+        }
+
+        await manager.pollProcessesOnce()
+        await manager.pollFilesOnce()
+        await manager.pollProcessesOnce()
+
+        let sessions = await store.sessions
+        #expect(sessions.count == 1)
+        #expect(sessions[0].status == .error)
+
+        let notifications = notifService.getNotifications()
+        #expect(notifications.count == 1)
+        #expect(notifications[0].body == "Session error")
+    }
+
+    // TC-SSM-05: Completed session removed after 30 seconds
+    @Test("Completed session removed after 30 seconds")
+    func completedSessionRemovedAfter30s() async {
+        let scanner = MockProcessScanner()
+        let testClock = TestClock()
+        let (manager, store, _, _, _) = await makeSut(scanner: scanner, testClock: testClock)
+
+        await scanner.setScanResults([
+            [makeProc()],
+            [],
+            []
+        ])
+
+        await manager.pollProcessesOnce()
+        await manager.pollProcessesOnce()
+
+        var sessions = await store.sessions
+        #expect(sessions.count == 1)
+        #expect(sessions[0].status == .completed)
+
+        testClock.advance(by: 31)
+        await manager.pollProcessesOnce()
+
+        sessions = await store.sessions
+        #expect(sessions.isEmpty)
+    }
+
+    // TC-SSM-06: Error session removed after 60 seconds
+    @Test("Error session removed after 60 seconds")
+    func errorSessionRemovedAfter60s() async {
+        let scanner = MockProcessScanner()
+        let fileReader = MockSessionFileReader()
+        let testClock = TestClock()
+        let (manager, store, _, _, _) = await makeSut(
+            scanner: scanner, fileReader: fileReader, testClock: testClock
+        )
+
+        let proc = makeProc()
+        await scanner.setScanResults([[proc], [], [], []])
+
+        let pathEncoder = makePathEncoder()
+        if let projectDir = pathEncoder.projectDirectory(for: proc.cwd!) {
+            await fileReader.setResult(
+                for: projectDir,
+                result: .success(makeSnapshot(hasError: true))
+            )
+        }
+
+        await manager.pollProcessesOnce()
+        await manager.pollFilesOnce()
+        await manager.pollProcessesOnce()  // → error
+
+        var sessions = await store.sessions
+        #expect(sessions.count == 1)
+        #expect(sessions[0].status == .error)
+
+        // 31 seconds — should still be there
+        testClock.advance(by: 31)
+        await manager.pollProcessesOnce()
+        sessions = await store.sessions
+        #expect(sessions.count == 1)
+
+        // 61 seconds total — should be removed
+        testClock.advance(by: 30)
+        await manager.pollProcessesOnce()
+        sessions = await store.sessions
+        #expect(sessions.isEmpty)
+    }
+
+    // TC-SSM-07: JSONL read failure → fileReadError
+    @Test("JSONL read failure sets fileReadError status")
+    func jsonlReadFailureSetsFileReadError() async {
+        let scanner = MockProcessScanner()
+        let fileReader = MockSessionFileReader()
+        let (manager, store, _, _, _) = await makeSut(scanner: scanner, fileReader: fileReader)
+
+        let proc = makeProc()
+        await scanner.setScanResults([[proc]])
+
+        let pathEncoder = makePathEncoder()
+        if let projectDir = pathEncoder.projectDirectory(for: proc.cwd!) {
+            await fileReader.setResult(
+                for: projectDir,
+                result: .failure(SessionFileError.noJsonlFile)
+            )
+        }
+
+        await manager.pollProcessesOnce()
+        await manager.pollFilesOnce()
+
+        let sessions = await store.sessions
+        #expect(sessions.count == 1)
+        #expect(sessions[0].status == .fileReadError)
+    }
+
+    // TC-SSM-08: fileReadError → running on successful read
+    @Test("fileReadError recovers to running on successful read")
+    func fileReadErrorRecoversToRunning() async {
+        let scanner = MockProcessScanner()
+        let fileReader = MockSessionFileReader()
+        let (manager, store, _, _, _) = await makeSut(scanner: scanner, fileReader: fileReader)
+
+        let proc = makeProc()
+        await scanner.setScanResults([[proc]])
+
+        let pathEncoder = makePathEncoder()
+        guard let projectDir = pathEncoder.projectDirectory(for: proc.cwd!) else {
+            Issue.record("Failed to create project directory")
+            return
+        }
+
+        // First: fail
+        await fileReader.setResult(for: projectDir, result: .failure(SessionFileError.noJsonlFile))
+        await manager.pollProcessesOnce()
+        await manager.pollFilesOnce()
+
+        var sessions = await store.sessions
+        #expect(sessions[0].status == .fileReadError)
+
+        // Second: succeed
+        await fileReader.setResult(for: projectDir, result: .success(makeSnapshot()))
+        await manager.pollFilesOnce()
+
+        sessions = await store.sessions
+        #expect(sessions[0].status == .running)
+    }
+
+    // TC-SSM-09: running → idle after 5 minutes
+    @Test("Running session becomes idle after idle threshold")
+    func runningBecomesIdleAfterThreshold() async {
+        let scanner = MockProcessScanner()
+        let testClock = TestClock()
+        let (manager, store, _, _, _) = await makeSut(
+            scanner: scanner, testClock: testClock, idleThreshold: 300
+        )
+
+        let proc = makeProc()
+        await scanner.setScanResults([
+            [proc],
+            [proc]
+        ])
+
+        await manager.pollProcessesOnce()
+
+        testClock.advance(by: 360)
+        await manager.pollProcessesOnce()
+
+        let sessions = await store.sessions
+        #expect(sessions.count == 1)
+        #expect(sessions[0].status == .idle)
+    }
+
+    // TC-SSM-10: idle → running when file is updated
+    @Test("Idle session becomes running when file is updated")
+    func idleBecomesRunningOnFileUpdate() async {
+        let scanner = MockProcessScanner()
+        let fileReader = MockSessionFileReader()
+        let testClock = TestClock()
+        let (manager, store, _, _, _) = await makeSut(
+            scanner: scanner, fileReader: fileReader, testClock: testClock, idleThreshold: 300
+        )
+
+        let proc = makeProc()
+        await scanner.setScanResults([
+            [proc],
+            [proc]
+        ])
+
+        let pathEncoder = makePathEncoder()
+        guard let projectDir = pathEncoder.projectDirectory(for: proc.cwd!) else {
+            Issue.record("Failed to create project directory")
+            return
+        }
+
+        await manager.pollProcessesOnce()
+
+        // Go idle
+        testClock.advance(by: 360)
+        await manager.pollProcessesOnce()
+
+        var sessions = await store.sessions
+        #expect(sessions[0].status == .idle)
+
+        // File updated after idle → should become running
+        let futureModified = testClock.now.addingTimeInterval(10)
+        await fileReader.setResult(
+            for: projectDir,
+            result: .success(makeSnapshot(lastModified: futureModified))
+        )
+        await manager.pollFilesOnce()
+
+        sessions = await store.sessions
+        #expect(sessions[0].status == .running)
+    }
+
+    // TC-SSM-11: CWD nil → not added
+    @Test("Process with nil CWD is not added")
+    func nilCwdNotAdded() async {
+        let scanner = MockProcessScanner()
+        let (manager, store, _, _, _) = await makeSut(scanner: scanner)
+
+        let proc = ClaudeProcessInfo(pid: 9999, tty: "s001", cwd: nil)
+        await scanner.setScanResults([[proc]])
+        await manager.pollProcessesOnce()
+
+        let sessions = await store.sessions
+        #expect(sessions.isEmpty)
+    }
+
+    // TC-SSM-12: Multiple sessions tracked simultaneously
+    @Test("Multiple sessions tracked correctly")
+    func multipleSessionsTracked() async {
+        let scanner = MockProcessScanner()
+        let (manager, store, _, _, _) = await makeSut(scanner: scanner)
+
+        await scanner.setScanResults([[
+            makeProc(pid: 1001, tty: "s001", cwd: "/Users/test/projectA"),
+            makeProc(pid: 1002, tty: "s002", cwd: "/Users/test/projectB"),
+            makeProc(pid: 1003, tty: "s003", cwd: "/Users/test/projectC")
+        ]])
+        await manager.pollProcessesOnce()
+
+        let sessions = await store.sessions
+        #expect(sessions.count == 3)
+    }
+}


### PR DESCRIPTION
## Summary

Closes #4
Part of Epic #1

- **SessionStateManager** actor 구현: 프로세스 폴링(10초) + 파일 폴링(30초)으로 Claude Code 세션 상태 추적
- **SessionStore** (@MainActor @Observable): SwiftUI 연동용 sessions 배열 관리
- **상태 전이 로직**: running → idle(5분 미변경) → completed/error(프로세스 소멸) → 지연 제거(30초/60초)
- **알림 트리거**: 프로세스 소멸 시 hasError 기반 "Session completed" / "Session error" macOS 알림
- **프로토콜 추출**: ProcessScannerProtocol, SessionFileReaderProtocol, NotificationServiceProtocol (테스트 가능성)
- **Rename**: `ProcessInfo` → `ClaudeProcessInfo` (Foundation.ProcessInfo 이름 충돌 해결)

## AC Coverage

| AC | 구현 | 테스트 |
|----|------|--------|
| AC-01 (10초 세션 감지) | processInterval: 10초 | TC-SSM-01 |
| AC-02 (10초 완료 업데이트) | markTerminated() | TC-SSM-03, TC-SSM-04 |
| AC-04 (30초 카드 갱신) | fileInterval: 30초 | TC-SSM-08, TC-SSM-10 |
| AC-09 (완료 알림) | notify("Session completed") | TC-SSM-03 |
| AC-10 (오류 알림) | notify("Session error") | TC-SSM-04 |

## Audit Summary

| Reviewer | Verdict | Notes |
|----------|---------|-------|
| QA | PASS (조건부) | 5 AC 전부 통과, BUG-01 수정 완료 |
| ZT | SECURE (수정 후) | actor isolation 검증, deinit Task 정리 추가 |

## Test plan

- [x] `swift build` 성공 (0 errors)
- [x] `swift test` 38/38 통과 (신규 11개 포함)
- [x] SessionStateManager 상태 전이 11개 TC 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)