### PR TITLE
feat: Presentation 계층 + App 조립 (#5)

### DIFF
--- a/ClaudeMonitor/Sources/ClaudeMonitor/App/AppDelegate.swift
+++ b/ClaudeMonitor/Sources/ClaudeMonitor/App/AppDelegate.swift
@@ -1,0 +1,27 @@
+import AppKit
+
+@MainActor
+final class AppDelegate: NSObject, NSApplicationDelegate {
+    private var menuBarController: MenuBarController?
+    private let sessionStore = SessionStore()
+    private var manager: SessionStateManager?
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        let viewModel = SessionListViewModel(store: sessionStore)
+        menuBarController = MenuBarController(viewModel: viewModel)
+        menuBarController?.setup()
+
+        let mgr = SessionStateManager(store: sessionStore)
+        manager = mgr
+
+        Task {
+            await NotificationService.shared.requestPermission()
+            await mgr.start()
+        }
+    }
+
+    func applicationWillTerminate(_ notification: Notification) {
+        let mgr = manager
+        Task { await mgr?.stop() }
+    }
+}

--- a/ClaudeMonitor/Sources/ClaudeMonitor/App/ClaudeMonitorApp.swift
+++ b/ClaudeMonitor/Sources/ClaudeMonitor/App/ClaudeMonitorApp.swift
@@ -1,25 +1,11 @@
-import SwiftUI
+import AppKit
 
 @main
-struct ClaudeMonitorApp: App {
-    @State private var sessionStore: SessionStore
-    @State private var manager: SessionStateManager
-
-    var body: some Scene {
-        Settings {
-            EmptyView()
-        }
-    }
-
-    init() {
-        let store = SessionStore()
-        let mgr = SessionStateManager(store: store)
-        _sessionStore = State(initialValue: store)
-        _manager = State(initialValue: mgr)
-
-        Task {
-            await NotificationService.shared.requestPermission()
-            await mgr.start()
-        }
+struct ClaudeMonitorApp {
+    static func main() {
+        let app = NSApplication.shared
+        let delegate = AppDelegate()
+        app.delegate = delegate
+        app.run()
     }
 }

--- a/ClaudeMonitor/Sources/ClaudeMonitor/Presentation/MenuBarController.swift
+++ b/ClaudeMonitor/Sources/ClaudeMonitor/Presentation/MenuBarController.swift
@@ -1,0 +1,78 @@
+import AppKit
+import SwiftUI
+
+@MainActor
+final class MenuBarController {
+    private var statusItem: NSStatusItem?
+    private let popover = NSPopover()
+    private let viewModel: SessionListViewModel
+
+    init(viewModel: SessionListViewModel) {
+        self.viewModel = viewModel
+    }
+
+    func setup() {
+        let item = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+
+        if let button = item.button {
+            let image = NSImage(
+                systemSymbolName: "terminal",
+                accessibilityDescription: "Claude Monitor"
+            )
+            button.image = image
+            button.imagePosition = .imageLeading
+            button.action = #selector(togglePopover)
+            button.target = self
+        }
+
+        statusItem = item
+
+        let hostingView = NSHostingController(rootView: PopoverView(viewModel: viewModel))
+        popover.contentViewController = hostingView
+        popover.contentSize = NSSize(width: 320, height: 400)
+        popover.behavior = .transient
+
+        updateIcon()
+        startObserving()
+    }
+
+    @objc private func togglePopover() {
+        guard let button = statusItem?.button else { return }
+
+        if popover.isShown {
+            popover.performClose(nil)
+        } else {
+            popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
+            popover.contentViewController?.view.window?.makeKey()
+        }
+    }
+
+    private func updateIcon() {
+        guard let button = statusItem?.button else { return }
+
+        let count = viewModel.activeCount
+        button.title = count > 0 ? "\(count)" : ""
+
+        let color: NSColor
+        if viewModel.hasError {
+            color = .systemRed
+        } else if count > 0 {
+            color = .labelColor
+        } else {
+            color = .systemGray
+        }
+
+        button.contentTintColor = color
+    }
+
+    private func startObserving() {
+        withObservationTracking {
+            _ = viewModel.sessions
+        } onChange: { [weak self] in
+            Task { @MainActor [weak self] in
+                self?.updateIcon()
+                self?.startObserving()
+            }
+        }
+    }
+}

--- a/ClaudeMonitor/Sources/ClaudeMonitor/Presentation/PopoverView.swift
+++ b/ClaudeMonitor/Sources/ClaudeMonitor/Presentation/PopoverView.swift
@@ -1,0 +1,75 @@
+import SwiftUI
+
+struct PopoverView: View {
+    let viewModel: SessionListViewModel
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+
+            if viewModel.sessions.isEmpty {
+                emptyState
+            } else {
+                sessionList
+            }
+
+            Divider()
+            footer
+        }
+        .frame(width: 320, height: 400)
+    }
+
+    private var header: some View {
+        HStack {
+            Text("Claude Monitor")
+                .font(.headline)
+            Spacer()
+            Text("\(viewModel.activeCount) active")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+    }
+
+    private var emptyState: some View {
+        VStack {
+            Spacer()
+            Text("실행 중인 세션 없음")
+                .foregroundStyle(.secondary)
+            Spacer()
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private var sessionList: some View {
+        ScrollView {
+            LazyVStack(spacing: 0) {
+                ForEach(viewModel.sessions) { session in
+                    SessionCardView(session: session) {
+                        viewModel.openInFinder(session: session)
+                    }
+
+                    if session.id != viewModel.sessions.last?.id {
+                        Divider().padding(.leading, 30)
+                    }
+                }
+            }
+        }
+    }
+
+    private var footer: some View {
+        HStack {
+            Spacer()
+            Button("Claude Monitor 종료") {
+                NSApplication.shared.terminate(nil)
+            }
+            .buttonStyle(.plain)
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            .padding(8)
+        }
+        .padding(.horizontal, 4)
+    }
+}

--- a/ClaudeMonitor/Sources/ClaudeMonitor/Presentation/SessionCardView.swift
+++ b/ClaudeMonitor/Sources/ClaudeMonitor/Presentation/SessionCardView.swift
@@ -1,0 +1,52 @@
+import SwiftUI
+
+struct SessionCardView: View {
+    let session: SessionInfo
+    let onTap: () -> Void
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Circle()
+                .fill(statusColor)
+                .frame(width: 8, height: 8)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(session.projectName)
+                    .font(.body)
+                    .fontWeight(.bold)
+                    .lineLimit(1)
+
+                Text("\(session.tty) · \(session.gitBranch)")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+
+                if session.status == .fileReadError {
+                    Text("데이터 읽기 실패")
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                } else if !session.lastAssistantText.isEmpty {
+                    Text(String(session.lastAssistantText.prefix(100)))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                }
+            }
+
+            Spacer()
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .contentShape(Rectangle())
+        .onTapGesture(perform: onTap)
+    }
+
+    private var statusColor: Color {
+        switch session.status {
+        case .running: .green
+        case .idle: .yellow
+        case .completed: .gray
+        case .error, .fileReadError: .red
+        }
+    }
+}

--- a/ClaudeMonitor/Sources/ClaudeMonitor/Presentation/SessionListViewModel.swift
+++ b/ClaudeMonitor/Sources/ClaudeMonitor/Presentation/SessionListViewModel.swift
@@ -1,0 +1,29 @@
+import AppKit
+
+@MainActor
+@Observable
+final class SessionListViewModel {
+    private let store: SessionStore
+
+    init(store: SessionStore) {
+        self.store = store
+    }
+
+    var sessions: [SessionInfo] {
+        store.sessions
+    }
+
+    var activeCount: Int {
+        store.sessions.filter { $0.status == .running || $0.status == .idle }.count
+    }
+
+    var hasError: Bool {
+        store.sessions.contains { $0.status == .error || $0.status == .fileReadError }
+    }
+
+    func openInFinder(session: SessionInfo) {
+        let path = session.projectPath.standardizedFileURL.path()
+        guard path.hasPrefix(NSHomeDirectory()) else { return }
+        NSWorkspace.shared.selectFile(nil, inFileViewerRootedAtPath: path)
+    }
+}


### PR DESCRIPTION
## Summary
- 메뉴바 앱 UI 전체 구현: SessionListViewModel, MenuBarController, PopoverView, SessionCardView, AppDelegate
- SwiftUI App → NSApplication 기반 AppDelegate로 전환하여 메뉴바 앱 제어 최적화
- 오류 시 빨간색 아이콘, Finder 열기 경로 검증(홈 디렉토리 하위만 허용), applicationWillTerminate 정리 로직 포함

## AC Coverage
| AC | Status |
|----|--------|
| AC-03 (empty state) | ✅ "실행 중인 세션 없음" 표시 |
| AC-05 (카드 정보) | ✅ 4개 정보 + fileReadError 표시 |
| AC-07 (세션 수) | ✅ 메뉴바 activeCount 표시 |
| AC-08 (오류 색상) | ✅ .systemRed 아이콘 |
| AC-11 (500ms) | ✅ NSPopover 동기 표시 |
| AC-12 (Finder) | ✅ selectFile + 경로 검증 |

## Audit Summary
- **QA**: PASS (38/38 tests, 0 critical bugs)
- **UX**: PASS (Fix Loop: orange→red, fileReadError 표시, 종료 버튼 레이블)
- **ZT**: SECURE (Fix Loop: 홈 디렉토리 검증, applicationWillTerminate 추가)

Closes #5
Part of Epic #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)