### PR TITLE
fix: 번들 없는 환경에서 UNUserNotificationCenter 크래시 방지

### DIFF
--- a/ClaudeMonitor/Sources/ClaudeMonitor/Infrastructure/NotificationService.swift
+++ b/ClaudeMonitor/Sources/ClaudeMonitor/Infrastructure/NotificationService.swift
@@ -3,12 +3,18 @@ import UserNotifications
 final class NotificationService: NotificationServiceProtocol, Sendable {
     static let shared = NotificationService()
 
+    private var isAvailable: Bool {
+        Bundle.main.bundleIdentifier != nil
+    }
+
     func requestPermission() async {
+        guard isAvailable else { return }
         _ = try? await UNUserNotificationCenter.current()
             .requestAuthorization(options: [.alert, .sound])
     }
 
     func notify(title: String, body: String) {
+        guard isAvailable else { return }
         let center = UNUserNotificationCenter.current()
         center.getNotificationSettings { settings in
             guard settings.authorizationStatus == .authorized else { return }


### PR DESCRIPTION
## Summary
- `swift run` 실행 시 `bundleIdentifier`가 nil이라 `UNUserNotificationCenter.current()` 크래시 발생
- `NotificationService`에 `Bundle.main.bundleIdentifier != nil` 가드 추가하여 안전하게 처리

Closes #10

## Test plan
- [x] `swift build` 성공
- [x] `swift run` 크래시 없이 실행 확인
- [x] `swift test` 38/38 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)