### PR TITLE
feat: SubagentInfo 모델 + SubagentFileReader 인프라

### DIFF
--- a/ClaudeMonitor/Sources/ClaudeMonitor/Domain/Models/SessionInfo.swift
+++ b/ClaudeMonitor/Sources/ClaudeMonitor/Domain/Models/SessionInfo.swift
@@ -24,4 +24,5 @@ struct SessionInfo: Identifiable, Sendable, Hashable {
     let lastAssistantText: String
     let status: SessionStatus
     let lastUpdated: Date
+    let subagents: [SubagentInfo]
 }

--- a/ClaudeMonitor/Sources/ClaudeMonitor/Domain/Models/SubagentInfo.swift
+++ b/ClaudeMonitor/Sources/ClaudeMonitor/Domain/Models/SubagentInfo.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+struct SubagentInfo: Identifiable, Sendable, Hashable {
+    let id: String
+    let agentType: String
+    let parentSessionId: String
+    let lastAssistantText: String
+    let lastUpdated: Date
+    let status: SessionStatus
+}

--- a/ClaudeMonitor/Sources/ClaudeMonitor/Domain/SessionStateManager.swift
+++ b/ClaudeMonitor/Sources/ClaudeMonitor/Domain/SessionStateManager.swift
@@ -154,7 +154,8 @@ actor SessionStateManager {
             gitBranch: "unknown",
             lastAssistantText: "",
             status: .running,
-            lastUpdated: now
+            lastUpdated: now,
+            subagents: []
         )
 
         managed[sessionId] = ManagedSession(
@@ -216,7 +217,8 @@ actor SessionStateManager {
             gitBranch: snapshot.gitBranch,
             lastAssistantText: snapshot.lastAssistantText,
             status: newStatus,
-            lastUpdated: now
+            lastUpdated: now,
+            subagents: session.info.subagents
         )
 
         session.hasError = snapshot.hasError
@@ -301,7 +303,8 @@ actor SessionStateManager {
             gitBranch: info.gitBranch,
             lastAssistantText: info.lastAssistantText,
             status: status,
-            lastUpdated: lastUpdated
+            lastUpdated: lastUpdated,
+            subagents: info.subagents
         )
     }
 

--- a/ClaudeMonitor/Sources/ClaudeMonitor/Infrastructure/SubagentFileReader.swift
+++ b/ClaudeMonitor/Sources/ClaudeMonitor/Infrastructure/SubagentFileReader.swift
@@ -1,0 +1,168 @@
+import Foundation
+
+actor SubagentFileReader {
+    private let claudeProjectsBase: URL
+
+    init(homeDirectory: URL = .homeDirectory) {
+        self.claudeProjectsBase = homeDirectory
+            .appending(path: ".claude/projects", directoryHint: .isDirectory)
+    }
+
+    func readSubagents(sessionDirectory: URL) -> [SubagentInfo] {
+        let basePath = claudeProjectsBase.standardizedFileURL.path()
+        let basePathWithSlash = basePath.hasSuffix("/") ? basePath : basePath + "/"
+        guard sessionDirectory.standardizedFileURL.path()
+            .hasPrefix(basePathWithSlash)
+        else {
+            return []
+        }
+
+        let subagentsDir = sessionDirectory
+            .appending(path: "subagents", directoryHint: .isDirectory)
+
+        let fm = FileManager.default
+        let contents: [URL]
+        do {
+            contents = try fm.contentsOfDirectory(
+                at: subagentsDir,
+                includingPropertiesForKeys: [.contentModificationDateKey],
+                options: [.skipsHiddenFiles, .skipsSubdirectoryDescendants]
+            )
+        } catch {
+            return []
+        }
+
+        let jsonlFiles = contents.filter {
+            $0.pathExtension == "jsonl" && $0.lastPathComponent.hasPrefix("agent-")
+        }
+
+        var results: [SubagentInfo] = []
+
+        for jsonlFile in jsonlFiles {
+            let agentId = extractAgentId(from: jsonlFile)
+            let metaFile = sessionDirectory
+                .appending(path: "subagents/\(agentId).meta.json")
+            let agentType = readAgentType(from: metaFile)
+
+            guard let parsed = parseSubagentJsonl(file: jsonlFile, agentId: agentId, agentType: agentType) else {
+                continue
+            }
+            results.append(parsed)
+        }
+
+        return results.sorted { $0.lastUpdated > $1.lastUpdated }
+    }
+
+    // MARK: - Private
+
+    private func extractAgentId(from jsonlFile: URL) -> String {
+        let name = jsonlFile.deletingPathExtension().lastPathComponent
+        return name
+    }
+
+    private func readAgentType(from metaFile: URL) -> String {
+        guard let data = try? Data(contentsOf: metaFile),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let rawType = json["agentType"] as? String
+        else {
+            return "unknown"
+        }
+        return String(rawType.prefix(100))
+    }
+
+    private func parseSubagentJsonl(file: URL, agentId: String, agentType: String) -> SubagentInfo? {
+        let handle: FileHandle
+        do {
+            handle = try FileHandle(forReadingFrom: file)
+        } catch {
+            return nil
+        }
+        defer { try? handle.close() }
+
+        let fileSize: UInt64
+        do {
+            fileSize = try handle.seekToEnd()
+        } catch {
+            return nil
+        }
+
+        guard fileSize > 0 else { return nil }
+
+        let readSize = min(fileSize, 16 * 1024)
+        try? handle.seek(toOffset: fileSize - readSize)
+
+        let data = handle.readData(ofLength: Int(readSize))
+        guard let text = String(data: data, encoding: .utf8) else { return nil }
+
+        let lines = text.split(separator: "\n").reversed()
+
+        var parentSessionId: String?
+        var lastAssistantText: String = ""
+        var lastUpdated: Date?
+        var foundAssistant = false
+        var hasError = false
+
+        for line in lines {
+            guard let jsonData = line.data(using: .utf8),
+                  let json = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any]
+            else { continue }
+
+            if parentSessionId == nil, let sid = json["sessionId"] as? String {
+                parentSessionId = sid
+            }
+
+            if lastUpdated == nil, let ts = json["timestamp"] as? String {
+                lastUpdated = parseTimestamp(ts)
+            }
+
+            let stopReason = json["stop_reason"] as? String
+            if stopReason != nil && stopReason != "end_turn" {
+                hasError = true
+            }
+
+            guard !foundAssistant else { continue }
+
+            guard json["type"] as? String == "assistant",
+                  let message = json["message"] as? [String: Any],
+                  message["role"] as? String == "assistant"
+            else { continue }
+
+            if let content = message["content"] as? [[String: Any]] {
+                let texts = content
+                    .filter { $0["type"] as? String == "text" }
+                    .compactMap { $0["text"] as? String }
+                lastAssistantText = String(texts.joined(separator: " ").prefix(500))
+            }
+            foundAssistant = true
+        }
+
+        let attrs = try? FileManager.default.attributesOfItem(atPath: file.path())
+        let fileDate = (attrs?[.modificationDate] as? Date) ?? Date()
+
+        let status: SessionStatus
+        if hasError {
+            status = .error
+        } else if let updated = lastUpdated, Date().timeIntervalSince(updated) > 300 {
+            status = .idle
+        } else {
+            status = .running
+        }
+
+        return SubagentInfo(
+            id: agentId,
+            agentType: agentType,
+            parentSessionId: parentSessionId ?? "unknown",
+            lastAssistantText: lastAssistantText,
+            lastUpdated: lastUpdated ?? fileDate,
+            status: status
+        )
+    }
+
+    private func parseTimestamp(_ ts: String) -> Date? {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = formatter.date(from: ts) { return date }
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter.date(from: ts)
+    }
+}

--- a/ClaudeMonitor/Tests/ClaudeMonitorTests/SubagentFileReaderTests.swift
+++ b/ClaudeMonitor/Tests/ClaudeMonitorTests/SubagentFileReaderTests.swift
@@ -1,0 +1,184 @@
+import Testing
+import Foundation
+@testable import ClaudeMonitor
+
+@Suite("SubagentFileReader Tests")
+struct SubagentFileReaderTests {
+
+    private func createTempDir() throws -> URL {
+        let tmpDir = FileManager.default.temporaryDirectory
+            .appending(path: UUID().uuidString, directoryHint: .isDirectory)
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        return tmpDir
+    }
+
+    private func setupSessionDir() throws -> (sessionDir: URL, reader: SubagentFileReader) {
+        let tmpDir = try createTempDir()
+        let sessionDir = tmpDir.appending(
+            path: ".claude/projects/test-project/session-abc",
+            directoryHint: .isDirectory
+        )
+        try FileManager.default.createDirectory(at: sessionDir, withIntermediateDirectories: true)
+        let reader = SubagentFileReader(
+            homeDirectory: tmpDir
+        )
+        return (sessionDir, reader)
+    }
+
+    private func createSubagentsDir(in sessionDir: URL) throws -> URL {
+        let subDir = sessionDir.appending(path: "subagents", directoryHint: .isDirectory)
+        try FileManager.default.createDirectory(at: subDir, withIntermediateDirectories: true)
+        return subDir
+    }
+
+    private let agentJsonl = """
+    {"type":"system","sessionId":"parent-session","timestamp":"2026-03-08T10:00:00Z"}
+    {"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Implementing the feature now."}]},"stop_reason":"end_turn","sessionId":"parent-session","timestamp":"2026-03-08T10:01:00Z"}
+    """
+
+    // AC-13: JSONL 파싱 정상 동작
+    @Test("reads subagent from valid JSONL")
+    func readValidSubagent() async throws {
+        let (sessionDir, reader) = try setupSessionDir()
+        let subDir = try createSubagentsDir(in: sessionDir)
+
+        let file = subDir.appending(path: "agent-abc123.jsonl")
+        try agentJsonl.write(to: file, atomically: true, encoding: .utf8)
+
+        let results = await reader.readSubagents(sessionDirectory: sessionDir)
+        #expect(results.count == 1)
+        #expect(results[0].id == "agent-abc123")
+        #expect(results[0].parentSessionId == "parent-session")
+        #expect(results[0].lastAssistantText == "Implementing the feature now.")
+    }
+
+    // AC-13: meta.json 파싱
+    @Test("reads agentType from meta.json")
+    func readAgentType() async throws {
+        let (sessionDir, reader) = try setupSessionDir()
+        let subDir = try createSubagentsDir(in: sessionDir)
+
+        let jsonlFile = subDir.appending(path: "agent-reviewer.jsonl")
+        try agentJsonl.write(to: jsonlFile, atomically: true, encoding: .utf8)
+
+        let metaFile = subDir.appending(path: "agent-reviewer.meta.json")
+        try #"{"agentType":"feature-dev:code-reviewer"}"#
+            .write(to: metaFile, atomically: true, encoding: .utf8)
+
+        let results = await reader.readSubagents(sessionDirectory: sessionDir)
+        #expect(results.count == 1)
+        #expect(results[0].agentType == "feature-dev:code-reviewer")
+    }
+
+    // AC-13: meta.json 없는 경우 unknown
+    @Test("agentType is unknown when meta.json missing")
+    func missingMetaJson() async throws {
+        let (sessionDir, reader) = try setupSessionDir()
+        let subDir = try createSubagentsDir(in: sessionDir)
+
+        let file = subDir.appending(path: "agent-abc123.jsonl")
+        try agentJsonl.write(to: file, atomically: true, encoding: .utf8)
+
+        let results = await reader.readSubagents(sessionDirectory: sessionDir)
+        #expect(results.count == 1)
+        #expect(results[0].agentType == "unknown")
+    }
+
+    // AC-13: subagents/ 디렉토리 없는 경우 빈 배열
+    @Test("returns empty array when subagents directory missing")
+    func noSubagentsDirectory() async throws {
+        let (sessionDir, reader) = try setupSessionDir()
+
+        let results = await reader.readSubagents(sessionDirectory: sessionDir)
+        #expect(results.isEmpty)
+    }
+
+    // AC-21: 경로 검증 위반 시 빈 배열
+    @Test("returns empty array for path outside claudeProjectsBase")
+    func pathViolation() async throws {
+        let tmpDir = try createTempDir()
+        let reader = SubagentFileReader(homeDirectory: tmpDir)
+
+        let outsideDir = FileManager.default.temporaryDirectory
+            .appending(path: "outside-\(UUID().uuidString)", directoryHint: .isDirectory)
+        try FileManager.default.createDirectory(at: outsideDir, withIntermediateDirectories: true)
+
+        let results = await reader.readSubagents(sessionDirectory: outsideDir)
+        #expect(results.isEmpty)
+    }
+
+    // RISK-02: agentType prefix(100) 제한
+    @Test("agentType truncated to 100 characters")
+    func agentTypeTruncation() async throws {
+        let (sessionDir, reader) = try setupSessionDir()
+        let subDir = try createSubagentsDir(in: sessionDir)
+
+        let jsonlFile = subDir.appending(path: "agent-long.jsonl")
+        try agentJsonl.write(to: jsonlFile, atomically: true, encoding: .utf8)
+
+        let longType = String(repeating: "x", count: 200)
+        let metaFile = subDir.appending(path: "agent-long.meta.json")
+        try "{\"agentType\":\"\(longType)\"}".write(to: metaFile, atomically: true, encoding: .utf8)
+
+        let results = await reader.readSubagents(sessionDirectory: sessionDir)
+        #expect(results.count == 1)
+        #expect(results[0].agentType.count == 100)
+    }
+
+    // AC-22: meta.json 파싱 오류 시 unknown
+    @Test("agentType is unknown when meta.json has invalid JSON")
+    func invalidMetaJson() async throws {
+        let (sessionDir, reader) = try setupSessionDir()
+        let subDir = try createSubagentsDir(in: sessionDir)
+
+        let jsonlFile = subDir.appending(path: "agent-bad.jsonl")
+        try agentJsonl.write(to: jsonlFile, atomically: true, encoding: .utf8)
+
+        let metaFile = subDir.appending(path: "agent-bad.meta.json")
+        try "not valid json".write(to: metaFile, atomically: true, encoding: .utf8)
+
+        let results = await reader.readSubagents(sessionDirectory: sessionDir)
+        #expect(results.count == 1)
+        #expect(results[0].agentType == "unknown")
+    }
+
+    // lastAssistantText prefix(500) 적용
+    @Test("lastAssistantText truncated to 500 characters")
+    func textTruncation() async throws {
+        let (sessionDir, reader) = try setupSessionDir()
+        let subDir = try createSubagentsDir(in: sessionDir)
+
+        let longText = String(repeating: "a", count: 1000)
+        let content = """
+        {"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"\(longText)"}]},"stop_reason":"end_turn","sessionId":"s1","timestamp":"2026-03-08T10:00:00Z"}
+        """
+        let file = subDir.appending(path: "agent-truncate.jsonl")
+        try content.write(to: file, atomically: true, encoding: .utf8)
+
+        let results = await reader.readSubagents(sessionDirectory: sessionDir)
+        #expect(results.count == 1)
+        #expect(results[0].lastAssistantText.count == 500)
+    }
+
+    // 복수 서브에이전트 파싱
+    @Test("reads multiple subagents sorted by lastUpdated")
+    func multipleSubagents() async throws {
+        let (sessionDir, reader) = try setupSessionDir()
+        let subDir = try createSubagentsDir(in: sessionDir)
+
+        let older = """
+        {"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"older"}]},"stop_reason":"end_turn","sessionId":"s1","timestamp":"2026-03-08T09:00:00Z"}
+        """
+        let newer = """
+        {"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"newer"}]},"stop_reason":"end_turn","sessionId":"s1","timestamp":"2026-03-08T11:00:00Z"}
+        """
+
+        try older.write(to: subDir.appending(path: "agent-old.jsonl"), atomically: true, encoding: .utf8)
+        try newer.write(to: subDir.appending(path: "agent-new.jsonl"), atomically: true, encoding: .utf8)
+
+        let results = await reader.readSubagents(sessionDirectory: sessionDir)
+        #expect(results.count == 2)
+        #expect(results[0].lastAssistantText == "newer")
+        #expect(results[1].lastAssistantText == "older")
+    }
+}


### PR DESCRIPTION
## Summary
- SubagentInfo 도메인 모델 생성 (Identifiable, Sendable, Hashable)
- SubagentFileReader actor 생성 (JSONL/meta.json 파싱, 경로 검증, tail-read 16KB)
- SessionInfo에 `subagents: [SubagentInfo]` 프로퍼티 추가
- 8개 단위 테스트 (AC-13, AC-21, AC-22 커버)

## AC Coverage
- **AC-13**: JSONL 파싱, meta.json 파싱, 디렉토리 없음 시 빈 배열
- **AC-21**: claudeProjectsBase + standardizedFileURL + hasPrefix 경로 검증
- **AC-22**: 8개 테스트 케이스 (JSONL, meta.json, 경로 위반, 절단)

## ZT 필수 개선 반영
- RISK-01: 경로 검증 패턴 (claudeProjectsBase + trailing slash + hasPrefix)
- RISK-02: agentType prefix(100) 제한
- RISK-03: .skipsSubdirectoryDescendants 명시

## Test Results
- 전체 47 tests passed (기존 39 + 신규 8)
- 빌드 성공

Closes #13
Part of Epic #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)