### PR TITLE
feat: SessionStateManager 서브에이전트 통합 + Selection enum

### DIFF
--- a/ClaudeMonitor/Sources/ClaudeMonitor/Domain/SessionStateManager.swift
+++ b/ClaudeMonitor/Sources/ClaudeMonitor/Domain/SessionStateManager.swift
@@ -12,6 +12,7 @@ actor SessionStateManager {
     private let sessionStore: SessionStore
     private let processScanner: any ProcessScannerProtocol
     private let fileReader: any SessionFileReaderProtocol
+    private let subagentReader: SubagentFileReader
     private let notificationService: any NotificationServiceProtocol
     private let pathEncoder: PathEncoder
     private let clock: @Sendable () -> Date
@@ -30,6 +31,7 @@ actor SessionStateManager {
         store: SessionStore,
         processScanner: any ProcessScannerProtocol = ProcessScanner(),
         fileReader: any SessionFileReaderProtocol = SessionFileReader(),
+        subagentReader: SubagentFileReader = SubagentFileReader(),
         notificationService: any NotificationServiceProtocol = NotificationService.shared,
         pathEncoder: PathEncoder = PathEncoder(),
         clock: @escaping @Sendable () -> Date = { Date() },
@@ -40,6 +42,7 @@ actor SessionStateManager {
         self.sessionStore = store
         self.processScanner = processScanner
         self.fileReader = fileReader
+        self.subagentReader = subagentReader
         self.notificationService = notificationService
         self.pathEncoder = pathEncoder
         self.clock = clock
@@ -128,6 +131,15 @@ actor SessionStateManager {
             do {
                 let snapshot = try await fileReader.readLatestSession(projectDirectory: projectDir)
                 updateFromSnapshot(sessionId: sessionId, snapshot: snapshot, now: now)
+
+                // Read subagents from session directory
+                let sessionDir = projectDir.appending(
+                    path: snapshot.sessionId, directoryHint: .isDirectory
+                )
+                let subagents = await subagentReader.readSubagents(
+                    sessionDirectory: sessionDir
+                )
+                updateSubagents(sessionId: sessionId, subagents: subagents)
             } catch {
                 markFileReadError(sessionId: sessionId, now: now)
             }
@@ -227,6 +239,27 @@ actor SessionStateManager {
             session.enteredCurrentStatusAt = now
         }
 
+        managed[sessionId] = session
+    }
+
+    private func updateSubagents(sessionId: String, subagents: [SubagentInfo]) {
+        guard var session = managed[sessionId] else { return }
+        session.info = SessionInfo(
+            id: session.info.id,
+            pid: session.info.pid,
+            tty: session.info.tty,
+            projectName: session.info.projectName,
+            projectPath: session.info.projectPath,
+            gitBranch: session.info.gitBranch,
+            lastAssistantText: session.info.lastAssistantText,
+            status: session.info.status,
+            lastUpdated: session.info.lastUpdated,
+            subagents: subagents
+        )
+        // AC-17: hasError rollup - include subagent errors
+        if subagents.contains(where: { $0.status == .error }) {
+            session.hasError = true
+        }
         managed[sessionId] = session
     }
 

--- a/ClaudeMonitor/Sources/ClaudeMonitor/Presentation/SessionListViewModel.swift
+++ b/ClaudeMonitor/Sources/ClaudeMonitor/Presentation/SessionListViewModel.swift
@@ -5,6 +5,13 @@ import AppKit
 final class SessionListViewModel {
     private let store: SessionStore
 
+    enum Selection: Hashable {
+        case session(id: String)
+        case subagent(sessionId: String, agentId: String)
+    }
+
+    var selection: Selection?
+
     init(store: SessionStore) {
         self.store = store
     }
@@ -17,8 +24,19 @@ final class SessionListViewModel {
         store.sessions.filter { $0.status == .running || $0.status == .idle }.count
     }
 
+    // AC-17: hasError includes subagent error rollup
     var hasError: Bool {
-        store.sessions.contains { $0.status == .error || $0.status == .fileReadError }
+        store.sessions.contains { session in
+            session.status == .error
+                || session.status == .fileReadError
+                || session.subagents.contains { $0.status == .error }
+        }
+    }
+
+    // AC-20: auto-select most recently updated session
+    func selectInitialIfNeeded() {
+        guard selection == nil, let first = store.sessions.first else { return }
+        selection = .session(id: first.id)
     }
 
     func openInFinder(session: SessionInfo) {


### PR DESCRIPTION
## Summary
- SessionStateManager에 SubagentFileReader 의존성 추가
- pollFilesOnce에서 30초 폴링 시 서브에이전트 정보 함께 읽기 (AC-18)
- updateSubagents 메서드: 서브에이전트 배열 업데이트 + hasError 롤업 (AC-17)
- SessionListViewModel에 Selection enum 추가 (session/subagent 선택)
- selectInitialIfNeeded: 초기 자동 선택 (AC-20)
- hasError에 서브에이전트 error 상태 포함 (AC-17)

## AC Coverage
- **AC-13**: pollFilesOnce에서 subagentReader.readSubagents 호출
- **AC-17**: hasError 롤업 - subagents.contains { $0.status == .error }
- **AC-18**: 기존 30초 fileInterval 폴링 재사용
- **AC-20**: selectInitialIfNeeded()

## Test Results
- 전체 47 tests passed
- 빌드 성공

Closes #14
Part of Epic #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)