### PR TITLE
feat: 트리 뷰 + 상세 패널 UI (#15)

### DIFF
--- a/ClaudeMonitor/Sources/ClaudeMonitor/Presentation/DetailPanelView.swift
+++ b/ClaudeMonitor/Sources/ClaudeMonitor/Presentation/DetailPanelView.swift
@@ -1,0 +1,216 @@
+import SwiftUI
+
+struct DetailPanelView: View {
+    let sessions: [SessionInfo]
+    let selection: SessionListViewModel.Selection?
+    let onOpenInFinder: (SessionInfo) -> Void
+
+    var body: some View {
+        Group {
+            if let selection {
+                switch selection {
+                case .session(let id):
+                    if let session = sessions.first(where: { $0.id == id }) {
+                        sessionDetail(session: session)
+                    } else {
+                        emptySelection
+                    }
+                case .subagent(let sessionId, let agentId):
+                    if let session = sessions.first(where: { $0.id == sessionId }),
+                       let agent = session.subagents.first(where: { $0.id == agentId }) {
+                        subagentDetail(agent: agent)
+                    } else {
+                        emptySelection
+                    }
+                }
+            } else {
+                emptySelection
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .padding(.horizontal, 16)
+        .padding(.top, 14)
+        .padding(.bottom, 12)
+    }
+
+    // MARK: - Session Detail
+
+    private func sessionDetail(session: SessionInfo) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // Header
+            HStack {
+                Text(session.projectName)
+                    .font(.title3)
+                    .fontWeight(.semibold)
+                    .lineLimit(1)
+                Spacer()
+                Button("Finder에서 보기") {
+                    onOpenInFinder(session)
+                }
+                .buttonStyle(.plain)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            }
+
+            Divider().padding(.vertical, 6)
+
+            // Meta info
+            VStack(alignment: .leading, spacing: 6) {
+                metaRow(icon: "folder", text: session.projectPath.path())
+                metaRow(icon: "arrow.triangle.branch", text: session.gitBranch)
+                metaRow(icon: "terminal", text: session.tty)
+                metaRow(icon: "clock", text: relativeTime(from: session.lastUpdated))
+            }
+
+            // Subagent summary
+            if !session.subagents.isEmpty {
+                Divider().padding(.vertical, 4)
+                subagentSummary(subagents: session.subagents)
+            }
+
+            // Last assistant text
+            if session.status == .fileReadError {
+                Divider().padding(.vertical, 4)
+                Text("데이터 읽기 실패")
+                    .font(.caption)
+                    .foregroundStyle(.red)
+            } else if !session.lastAssistantText.isEmpty {
+                Divider().padding(.vertical, 4)
+                ScrollView {
+                    Text(session.lastAssistantText)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            }
+        }
+    }
+
+    // MARK: - Subagent Detail
+
+    private func subagentDetail(agent: SubagentInfo) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // Header
+            HStack {
+                Text(displayName(for: agent.agentType))
+                    .font(.title3)
+                    .fontWeight(.semibold)
+                    .lineLimit(1)
+                Spacer()
+                statusBadge(status: agent.status)
+            }
+
+            Divider().padding(.vertical, 6)
+
+            // Meta info
+            VStack(alignment: .leading, spacing: 6) {
+                metaRow(icon: "person.crop.circle", text: agent.id)
+                metaRow(icon: "clock", text: relativeTime(from: agent.lastUpdated))
+            }
+
+            // Last assistant text
+            if !agent.lastAssistantText.isEmpty {
+                Divider().padding(.vertical, 4)
+                ScrollView {
+                    Text(agent.lastAssistantText)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            }
+        }
+    }
+
+    // MARK: - Empty Selection
+
+    private var emptySelection: some View {
+        VStack {
+            Spacer()
+            Text("항목을 선택하세요")
+                .font(.body)
+                .foregroundStyle(.secondary)
+            Spacer()
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    // MARK: - Helpers
+
+    private func metaRow(icon: String, text: String) -> some View {
+        HStack(spacing: 6) {
+            Image(systemName: icon)
+                .font(.system(size: 12))
+                .foregroundStyle(.secondary)
+                .frame(width: 16)
+            Text(text)
+                .font(.caption)
+                .lineLimit(2)
+                .truncationMode(.middle)
+        }
+    }
+
+    private func subagentSummary(subagents: [SubagentInfo]) -> some View {
+        let grouped = Dictionary(grouping: subagents, by: \.status)
+        let statuses: [SessionStatus] = [.running, .idle, .completed, .error]
+
+        return HStack(spacing: 12) {
+            ForEach(statuses, id: \.self) { status in
+                if let agents = grouped[status], !agents.isEmpty {
+                    HStack(spacing: 4) {
+                        Circle()
+                            .fill(statusColor(for: status))
+                            .frame(width: 6, height: 6)
+                        Text("\(agents.count) \(statusLabel(status))")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+        }
+    }
+
+    private func statusBadge(status: SessionStatus) -> some View {
+        Text(statusLabel(status))
+            .font(.caption2)
+            .foregroundStyle(statusColor(for: status).opacity(0.85))
+            .padding(.horizontal, 8)
+            .padding(.vertical, 2)
+            .background(
+                Capsule()
+                    .fill(statusColor(for: status).opacity(0.15))
+            )
+    }
+
+    private func statusColor(for status: SessionStatus) -> Color {
+        switch status {
+        case .running: .green
+        case .idle: .yellow
+        case .completed: .gray
+        case .error, .fileReadError: .red
+        }
+    }
+
+    private func statusLabel(_ status: SessionStatus) -> String {
+        switch status {
+        case .running: "running"
+        case .idle: "idle"
+        case .completed: "completed"
+        case .error: "error"
+        case .fileReadError: "error"
+        }
+    }
+
+    private func displayName(for agentType: String) -> String {
+        if agentType == "unknown" { return "Agent" }
+        if let colonIndex = agentType.lastIndex(of: ":") {
+            return String(agentType[agentType.index(after: colonIndex)...])
+        }
+        return agentType
+    }
+
+    private func relativeTime(from date: Date) -> String {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .short
+        return formatter.localizedString(for: date, relativeTo: Date())
+    }
+}

--- a/ClaudeMonitor/Sources/ClaudeMonitor/Presentation/MenuBarController.swift
+++ b/ClaudeMonitor/Sources/ClaudeMonitor/Presentation/MenuBarController.swift
@@ -29,7 +29,7 @@ final class MenuBarController {
 
         let hostingView = NSHostingController(rootView: PopoverView(viewModel: viewModel))
         popover.contentViewController = hostingView
-        popover.contentSize = NSSize(width: 320, height: 400)
+        popover.contentSize = NSSize(width: 680, height: 460)
         popover.behavior = .transient
 
         updateIcon()

--- a/ClaudeMonitor/Sources/ClaudeMonitor/Presentation/PopoverView.swift
+++ b/ClaudeMonitor/Sources/ClaudeMonitor/Presentation/PopoverView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct PopoverView: View {
-    let viewModel: SessionListViewModel
+    @Bindable var viewModel: SessionListViewModel
 
     var body: some View {
         VStack(spacing: 0) {
@@ -11,13 +11,16 @@ struct PopoverView: View {
             if viewModel.sessions.isEmpty {
                 emptyState
             } else {
-                sessionList
+                contentArea
             }
 
             Divider()
             footer
         }
-        .frame(width: 320, height: 400)
+        .frame(width: 680, height: 460)
+        .onAppear {
+            viewModel.selectInitialIfNeeded()
+        }
     }
 
     private var header: some View {
@@ -43,19 +46,22 @@ struct PopoverView: View {
         .frame(maxWidth: .infinity)
     }
 
-    private var sessionList: some View {
-        ScrollView {
-            LazyVStack(spacing: 0) {
-                ForEach(viewModel.sessions) { session in
-                    SessionCardView(session: session) {
-                        viewModel.openInFinder(session: session)
-                    }
+    private var contentArea: some View {
+        HStack(spacing: 0) {
+            SessionTreeView(
+                sessions: viewModel.sessions,
+                selection: $viewModel.selection
+            )
 
-                    if session.id != viewModel.sessions.last?.id {
-                        Divider().padding(.leading, 30)
-                    }
+            Divider()
+
+            DetailPanelView(
+                sessions: viewModel.sessions,
+                selection: viewModel.selection,
+                onOpenInFinder: { session in
+                    viewModel.openInFinder(session: session)
                 }
-            }
+            )
         }
     }
 

--- a/ClaudeMonitor/Sources/ClaudeMonitor/Presentation/SessionTreeView.swift
+++ b/ClaudeMonitor/Sources/ClaudeMonitor/Presentation/SessionTreeView.swift
@@ -1,0 +1,158 @@
+import SwiftUI
+
+struct SessionTreeView: View {
+    let sessions: [SessionInfo]
+    @Binding var selection: SessionListViewModel.Selection?
+    @State private var expandedSessions: Set<String> = []
+
+    var body: some View {
+        ScrollView {
+            LazyVStack(spacing: 0) {
+                ForEach(Array(sessions.enumerated()), id: \.element.id) { index, session in
+                    rootNode(session: session)
+
+                    if expandedSessions.contains(session.id) {
+                        ForEach(session.subagents) { agent in
+                            childNode(agent: agent, sessionId: session.id)
+                        }
+                    }
+
+                    if index < sessions.count - 1 {
+                        Divider().padding(.leading, 10)
+                    }
+                }
+            }
+        }
+        .frame(width: 220)
+        .onAppear {
+            // Initially expand all sessions that have subagents
+            for session in sessions where !session.subagents.isEmpty {
+                expandedSessions.insert(session.id)
+            }
+        }
+    }
+
+    // MARK: - Root Node
+
+    private func rootNode(session: SessionInfo) -> some View {
+        let isSelected = selection == .session(id: session.id)
+
+        return HStack(alignment: .top, spacing: 6) {
+            // Chevron
+            if session.subagents.isEmpty {
+                Color.clear.frame(width: 16, height: 16)
+            } else {
+                Image(systemName: expandedSessions.contains(session.id)
+                      ? "chevron.down" : "chevron.right")
+                    .font(.system(size: 10))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 16, height: 16)
+            }
+
+            // Status indicator (AC-17: rollup)
+            Circle()
+                .fill(rootStatusColor(session: session))
+                .frame(width: 8, height: 8)
+                .padding(.top, 4)
+
+            // Text
+            VStack(alignment: .leading, spacing: 2) {
+                Text(session.projectName)
+                    .font(.body)
+                    .fontWeight(.medium)
+                    .lineLimit(1)
+
+                Text(session.tty)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+
+            Spacer()
+        }
+        .padding(.leading, 10)
+        .padding(.trailing, 8)
+        .padding(.vertical, 8)
+        .frame(minHeight: 40)
+        .background(
+            isSelected
+                ? RoundedRectangle(cornerRadius: 6)
+                    .fill(Color.accentColor.opacity(0.15))
+                    .padding(.horizontal, 4)
+                : nil
+        )
+        .contentShape(Rectangle())
+        .onTapGesture {
+            selection = .session(id: session.id)
+            if !session.subagents.isEmpty {
+                withAnimation(.easeInOut(duration: 0.15)) {
+                    if expandedSessions.contains(session.id) {
+                        expandedSessions.remove(session.id)
+                    } else {
+                        expandedSessions.insert(session.id)
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Child Node
+
+    private func childNode(agent: SubagentInfo, sessionId: String) -> some View {
+        let isSelected = selection == .subagent(sessionId: sessionId, agentId: agent.id)
+
+        return HStack(spacing: 6) {
+            Circle()
+                .fill(statusColor(for: agent.status))
+                .frame(width: 6, height: 6)
+
+            Text(displayName(for: agent.agentType))
+                .font(.caption)
+                .lineLimit(1)
+
+            Spacer()
+        }
+        .padding(.leading, 26)
+        .padding(.trailing, 8)
+        .padding(.vertical, 6)
+        .frame(minHeight: 28)
+        .background(
+            isSelected
+                ? RoundedRectangle(cornerRadius: 6)
+                    .fill(Color.accentColor.opacity(0.15))
+                    .padding(.horizontal, 4)
+                : nil
+        )
+        .contentShape(Rectangle())
+        .onTapGesture {
+            selection = .subagent(sessionId: sessionId, agentId: agent.id)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func rootStatusColor(session: SessionInfo) -> Color {
+        // AC-17: subagent error rollup
+        if session.subagents.contains(where: { $0.status == .error }) {
+            return .red
+        }
+        return statusColor(for: session.status)
+    }
+
+    private func statusColor(for status: SessionStatus) -> Color {
+        switch status {
+        case .running: .green
+        case .idle: .yellow
+        case .completed: .gray
+        case .error, .fileReadError: .red
+        }
+    }
+
+    private func displayName(for agentType: String) -> String {
+        if agentType == "unknown" { return "Agent" }
+        if let colonIndex = agentType.lastIndex(of: ":") {
+            return String(agentType[agentType.index(after: colonIndex)...])
+        }
+        return agentType
+    }
+}


### PR DESCRIPTION
## Summary
- 세션 목록을 2열 레이아웃(트리 사이드바 220pt + 상세 패널 459pt)으로 변경
- SessionTreeView: 세션/서브에이전트 계층 구조, chevron 접기/펼치기, AC-17 상태 롤업
- DetailPanelView: 세션/서브에이전트 상세 정보, 상태 배지, 서브에이전트 요약

## Changes
| File | Type | Description |
|------|------|-------------|
| `SessionTreeView.swift` | New | 트리 사이드바 (루트/자식 노드, 선택, 확장) |
| `DetailPanelView.swift` | New | 상세 패널 (세션/서브에이전트/빈 선택 상태) |
| `PopoverView.swift` | Modified | HStack 2열 레이아웃, @Bindable 바인딩 |
| `MenuBarController.swift` | Modified | popover 크기 680x460 |

## Acceptance Criteria
- [x] AC-14: 트리 사이드바에 세션(루트) + 서브에이전트(자식) 계층 표시
- [x] AC-15: 서브에이전트 노드에 agentType + 상태 인디케이터 표시
- [x] AC-16: 루트/자식 노드 선택 시 상세 패널에 메타 정보 표시
- [x] AC-17: 자식 에이전트 error 시 부모 루트 노드 인디케이터 red 롤업
- [x] AC-19: 서브에이전트 없는 세션은 기존과 동일하게 루트 노드만 표시
- [x] AC-20: popover 열릴 때 가장 최근 업데이트된 세션 자동 선택

## Test Plan
- [x] 빌드 성공 (`swift build`)
- [x] 전체 47개 테스트 통과 (`swift test`)
- [x] UI 명세(.team/ui-spec.md) 기반 구현 검증

Closes #15
Part of Epic #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)