### PR TITLE
fix: 메뉴바 아이콘 우클릭 컨텍스트 메뉴 수정

### DIFF
--- a/ClaudeMonitor/Sources/ClaudeMonitor/Presentation/MenuBarController.swift
+++ b/ClaudeMonitor/Sources/ClaudeMonitor/Presentation/MenuBarController.swift
@@ -7,6 +7,7 @@ final class MenuBarController {
     private let popover = NSPopover()
     private let viewModel: SessionListViewModel
     private let mainWindowController: MainWindowController
+    private var rightClickMonitor: Any?
 
     init(viewModel: SessionListViewModel, mainWindowController: MainWindowController) {
         self.viewModel = viewModel
@@ -23,12 +24,27 @@ final class MenuBarController {
             )
             button.image = image
             button.imagePosition = .imageLeading
-            button.sendAction(on: [.leftMouseUp, .rightMouseDown])
-            button.action = #selector(handleClick(_:))
+            button.action = #selector(handleLeftClick(_:))
             button.target = self
         }
 
         statusItem = item
+
+        rightClickMonitor = NSEvent.addLocalMonitorForEvents(matching: .rightMouseDown) {
+            [weak self] event in
+            guard let self,
+                  let button = self.statusItem?.button,
+                  let window = button.window,
+                  window == event.window else {
+                return event
+            }
+            let locationInButton = button.convert(event.locationInWindow, from: nil)
+            if button.bounds.contains(locationInButton) {
+                self.showContextMenu()
+                return nil
+            }
+            return event
+        }
 
         let hostingView = NSHostingController(rootView: PopoverView(viewModel: viewModel))
         popover.contentViewController = hostingView
@@ -39,14 +55,8 @@ final class MenuBarController {
         startObserving()
     }
 
-    @objc private func handleClick(_ sender: NSStatusBarButton) {
-        guard let event = NSApp.currentEvent else { return }
-
-        if event.type == .rightMouseDown {
-            showContextMenu()
-        } else {
-            togglePopover()
-        }
+    @objc private func handleLeftClick(_ sender: NSStatusBarButton) {
+        togglePopover()
     }
 
     private func togglePopover() {


### PR DESCRIPTION
## Summary
- 메뉴바 터미널 아이콘 우클릭 시 컨텍스트 메뉴가 표시되지 않는 버그 수정
- `sendAction(on: .rightMouseDown)` → `NSEvent.addLocalMonitorForEvents` 방식으로 변경

## Test plan
- [x] `swift build` 성공
- [x] 47개 테스트 통과 (`swift test`)
- [ ] 앱 실행 후 메뉴바 아이콘 우클릭 → "윈도우로 열기" / "종료" 메뉴 표시 확인
- [ ] 좌클릭 → popover 정상 동작 확인

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)