### PR TITLE
메뉴바 UX 개선: 우클릭 제거 및 popover 버튼 추가

### DIFF
--- a/ClaudeMonitor/Sources/ClaudeMonitor/Presentation/MenuBarController.swift
+++ b/ClaudeMonitor/Sources/ClaudeMonitor/Presentation/MenuBarController.swift
@@ -7,7 +7,6 @@ final class MenuBarController {
     private let popover = NSPopover()
     private let viewModel: SessionListViewModel
     private let mainWindowController: MainWindowController
-    private var rightClickMonitor: Any?
 
     init(viewModel: SessionListViewModel, mainWindowController: MainWindowController) {
         self.viewModel = viewModel
@@ -24,29 +23,20 @@ final class MenuBarController {
             )
             button.image = image
             button.imagePosition = .imageLeading
-            button.action = #selector(handleLeftClick(_:))
+            button.action = #selector(togglePopover)
             button.target = self
         }
 
         statusItem = item
 
-        rightClickMonitor = NSEvent.addLocalMonitorForEvents(matching: .rightMouseDown) {
-            [weak self] event in
-            guard let self,
-                  let button = self.statusItem?.button,
-                  let window = button.window,
-                  window == event.window else {
-                return event
-            }
-            let locationInButton = button.convert(event.locationInWindow, from: nil)
-            if button.bounds.contains(locationInButton) {
-                self.showContextMenu()
-                return nil
-            }
-            return event
-        }
-
-        let hostingView = NSHostingController(rootView: PopoverView(viewModel: viewModel))
+        let hostingView = NSHostingController(
+            rootView: PopoverView(
+                viewModel: viewModel,
+                onOpenWindow: { [weak self] in
+                    self?.openWindow()
+                }
+            )
+        )
         popover.contentViewController = hostingView
         popover.contentSize = NSSize(width: 680, height: 460)
         popover.behavior = .transient
@@ -55,11 +45,7 @@ final class MenuBarController {
         startObserving()
     }
 
-    @objc private func handleLeftClick(_ sender: NSStatusBarButton) {
-        togglePopover()
-    }
-
-    private func togglePopover() {
+    @objc private func togglePopover() {
         guard let button = statusItem?.button else { return }
 
         if popover.isShown {
@@ -70,41 +56,9 @@ final class MenuBarController {
         }
     }
 
-    private func showContextMenu() {
-        let menu = NSMenu()
-
-        let openWindowItem = NSMenuItem(
-            title: "윈도우로 열기",
-            action: #selector(openWindow),
-            keyEquivalent: ""
-        )
-        openWindowItem.target = self
-        menu.addItem(openWindowItem)
-
-        menu.addItem(.separator())
-
-        let quitItem = NSMenuItem(
-            title: "종료",
-            action: #selector(quitApp),
-            keyEquivalent: ""
-        )
-        quitItem.target = self
-        menu.addItem(quitItem)
-
-        statusItem?.menu = menu
-        statusItem?.button?.performClick(nil)
-        statusItem?.menu = nil
-    }
-
-    @objc private func openWindow() {
-        if popover.isShown {
-            popover.performClose(nil)
-        }
+    private func openWindow() {
+        popover.performClose(nil)
         mainWindowController.openOrFocus()
-    }
-
-    @objc private func quitApp() {
-        NSApplication.shared.terminate(nil)
     }
 
     private func updateIcon() {

--- a/ClaudeMonitor/Sources/ClaudeMonitor/Presentation/PopoverView.swift
+++ b/ClaudeMonitor/Sources/ClaudeMonitor/Presentation/PopoverView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct PopoverView: View {
     @Bindable var viewModel: SessionListViewModel
+    var onOpenWindow: (() -> Void)?
 
     var body: some View {
         VStack(spacing: 0) {
@@ -92,16 +93,26 @@ struct PopoverView: View {
     }
 
     private var footer: some View {
-        HStack {
+        HStack(spacing: 12) {
+            Button {
+                onOpenWindow?()
+            } label: {
+                Label("윈도우로 열기", systemImage: "macwindow")
+            }
+            .buttonStyle(.plain)
+            .font(.caption)
+            .foregroundStyle(.secondary)
+
             Spacer()
-            Button("Claude Monitor 종료") {
+
+            Button("종료") {
                 NSApplication.shared.terminate(nil)
             }
             .buttonStyle(.plain)
             .font(.caption)
             .foregroundStyle(.secondary)
-            .padding(8)
         }
-        .padding(.horizontal, 4)
+        .padding(.horizontal, 12)
+        .frame(height: 32)
     }
 }

--- a/ClaudeMonitor/Sources/ClaudeMonitor/Presentation/SessionTreeView.swift
+++ b/ClaudeMonitor/Sources/ClaudeMonitor/Presentation/SessionTreeView.swift
@@ -24,11 +24,6 @@ struct SessionTreeView: View {
             }
         }
         .frame(width: 220)
-        .onAppear {
-            for session in sessions where !session.subagents.isEmpty {
-                expandedSessions.insert(session.id)
-            }
-        }
     }
 
     // MARK: - Root Node

--- a/ClaudeMonitor/scripts/bundle.sh
+++ b/ClaudeMonitor/scripts/bundle.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+APP_NAME="ClaudeMonitor"
+BUILD_DIR="$PROJECT_DIR/.build/debug"
+BUNDLE_DIR="$PROJECT_DIR/.build/${APP_NAME}.app"
+
+echo "Building..."
+cd "$PROJECT_DIR"
+swift build
+
+echo "Creating .app bundle..."
+rm -rf "$BUNDLE_DIR"
+mkdir -p "$BUNDLE_DIR/Contents/MacOS"
+mkdir -p "$BUNDLE_DIR/Contents/Resources"
+
+cp "$BUILD_DIR/$APP_NAME" "$BUNDLE_DIR/Contents/MacOS/$APP_NAME"
+cp "$PROJECT_DIR/Sources/$APP_NAME/App/Info.plist" "$BUNDLE_DIR/Contents/Info.plist"
+
+# Add CFBundleIdentifier and CFBundleExecutable to Info.plist
+/usr/libexec/PlistBuddy -c "Add :CFBundleIdentifier string com.bombo.ClaudeMonitor" "$BUNDLE_DIR/Contents/Info.plist" 2>/dev/null || true
+/usr/libexec/PlistBuddy -c "Add :CFBundleExecutable string $APP_NAME" "$BUNDLE_DIR/Contents/Info.plist" 2>/dev/null || true
+/usr/libexec/PlistBuddy -c "Add :CFBundleName string $APP_NAME" "$BUNDLE_DIR/Contents/Info.plist" 2>/dev/null || true
+/usr/libexec/PlistBuddy -c "Add :CFBundlePackageType string APPL" "$BUNDLE_DIR/Contents/Info.plist" 2>/dev/null || true
+
+echo "Bundle created: $BUNDLE_DIR"
+echo "Run with: open $BUNDLE_DIR"


### PR DESCRIPTION
## Summary
- 메뉴바 아이콘 우클릭 기능 제거 (macOS NSStatusBarButton 우클릭 미지원)
- PopoverView footer에 "윈도우로 열기" / "종료" 버튼 추가
- SessionTreeView 서브에이전트 자동 펼침 비활성화
- SPM 빌드를 .app 번들로 변환하는 스크립트 추가

## Test plan
- [ ] 메뉴바 아이콘 좌클릭 → popover 정상 표시
- [ ] "윈도우로 열기" 클릭 → 메인 윈도우 열림 + popover 닫힘
- [ ] "종료" 클릭 → 앱 종료
- [ ] 서브에이전트가 접힌 상태로 시작, 클릭 시 펼침

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)