### PR TITLE
Footer에 앱 실행 상태 인디케이터 추가

### DIFF
--- a/ClaudeMonitor/Sources/ClaudeMonitor/Presentation/MainWindowView.swift
+++ b/ClaudeMonitor/Sources/ClaudeMonitor/Presentation/MainWindowView.swift
@@ -94,7 +94,10 @@ struct MainWindowView: View {
 
     private var footer: some View {
         HStack {
+            StatusDotView(status: viewModel.statusSummary)
+
             Spacer()
+
             Text("Claude Monitor v3")
                 .font(.caption2)
                 .foregroundStyle(.tertiary)

--- a/ClaudeMonitor/Sources/ClaudeMonitor/Presentation/PopoverView.swift
+++ b/ClaudeMonitor/Sources/ClaudeMonitor/Presentation/PopoverView.swift
@@ -105,6 +105,10 @@ struct PopoverView: View {
 
             Spacer()
 
+            StatusDotView(status: viewModel.statusSummary)
+
+            Spacer()
+
             Button("종료") {
                 NSApplication.shared.terminate(nil)
             }

--- a/ClaudeMonitor/Sources/ClaudeMonitor/Presentation/SessionListViewModel.swift
+++ b/ClaudeMonitor/Sources/ClaudeMonitor/Presentation/SessionListViewModel.swift
@@ -1,5 +1,11 @@
 import AppKit
 
+enum AppStatus: Sendable {
+    case monitoring(count: Int)
+    case idle
+    case error
+}
+
 @MainActor
 @Observable
 final class SessionListViewModel {
@@ -22,6 +28,12 @@ final class SessionListViewModel {
 
     var activeCount: Int {
         store.sessions.filter { $0.status == .running || $0.status == .idle }.count
+    }
+
+    var statusSummary: AppStatus {
+        if hasError { return .error }
+        if activeCount > 0 { return .monitoring(count: activeCount) }
+        return .idle
     }
 
     // AC-17: hasError includes subagent error rollup

--- a/ClaudeMonitor/Sources/ClaudeMonitor/Presentation/StatusDotView.swift
+++ b/ClaudeMonitor/Sources/ClaudeMonitor/Presentation/StatusDotView.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+
+struct StatusDotView: View {
+    let status: AppStatus
+
+    var body: some View {
+        HStack(spacing: 4) {
+            Circle()
+                .fill(dotColor)
+                .frame(width: 6, height: 6)
+
+            Text(label)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var dotColor: Color {
+        switch status {
+        case .monitoring: .green
+        case .idle: .secondary
+        case .error: .red
+        }
+    }
+
+    private var label: String {
+        switch status {
+        case .monitoring(let count): "세션 \(count)개 모니터링 중"
+        case .idle: "대기 중"
+        case .error: "오류 감지됨"
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- AppStatus enum + statusSummary computed property 추가 (SessionListViewModel)
- StatusDotView 공용 컴포넌트 신규 생성 (녹색/회색/빨간 점 + 상태 텍스트)
- PopoverView footer 중앙에 상태 인디케이터 삽입
- MainWindowView footer 좌측에 상태 인디케이터 삽입

## Audit Summary
- QA: 빌드 성공, 47개 테스트 전체 통과
- ZT: CONDITIONAL (Critical GAP 없음)

## Test plan
- [ ] 세션 활성 시 녹색 점 + "세션 N개 모니터링 중" 표시 확인
- [ ] 세션 없을 때 회색 점 + "대기 중" 표시 확인
- [ ] 오류 발생 시 빨간 점 + "오류 감지됨" 표시 확인
- [ ] PopoverView/MainWindowView 양쪽 footer에서 동일하게 동작

Closes #29
Part of Epic #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)