### PR TITLE
fix: Footer 상태 인디케이터 가시성 개선 및 fileReadError 세션 관리

### DIFF
--- a/ClaudeMonitor/Sources/ClaudeMonitor/App/AppDelegate.swift
+++ b/ClaudeMonitor/Sources/ClaudeMonitor/App/AppDelegate.swift
@@ -8,7 +8,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var manager: SessionStateManager?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
-        let viewModel = SessionListViewModel(store: sessionStore)
+        let mgr = SessionStateManager(store: sessionStore)
+        manager = mgr
+
+        let viewModel = SessionListViewModel(store: sessionStore, stateManager: mgr)
         let windowController = MainWindowController(viewModel: viewModel)
         mainWindowController = windowController
         menuBarController = MenuBarController(
@@ -16,9 +19,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             mainWindowController: windowController
         )
         menuBarController?.setup()
-
-        let mgr = SessionStateManager(store: sessionStore)
-        manager = mgr
 
         Task {
             await NotificationService.shared.requestPermission()

--- a/ClaudeMonitor/Sources/ClaudeMonitor/Domain/Models/SessionStatus.swift
+++ b/ClaudeMonitor/Sources/ClaudeMonitor/Domain/Models/SessionStatus.swift
@@ -1,7 +1,30 @@
+enum FileReadErrorReason: Sendable, Hashable {
+    case noJsonlFile
+    case noAssistantMessage
+    case encodingError
+    case pathViolation
+    case unknown
+}
+
+extension FileReadErrorReason {
+    init(from error: Error) {
+        if let fileError = error as? SessionFileError {
+            switch fileError {
+            case .noJsonlFile: self = .noJsonlFile
+            case .noAssistantMessage: self = .noAssistantMessage
+            case .encodingError: self = .encodingError
+            case .pathViolation: self = .pathViolation
+            }
+        } else {
+            self = .unknown
+        }
+    }
+}
+
 enum SessionStatus: Sendable, Hashable {
     case running
     case idle
     case completed
     case error
-    case fileReadError
+    case fileReadError(reason: FileReadErrorReason)
 }

--- a/ClaudeMonitor/Sources/ClaudeMonitor/Domain/SessionStateManager.swift
+++ b/ClaudeMonitor/Sources/ClaudeMonitor/Domain/SessionStateManager.swift
@@ -24,6 +24,7 @@ actor SessionStateManager {
     private var pendingRemovals: [PendingRemoval] = []
     private var previousPids: Set<Int> = []
     private var pidToSessionId: [Int: String] = [:]
+    private var dismissedSessionIds: Set<String> = []
     private var processTask: Task<Void, Never>?
     private var fileTask: Task<Void, Never>?
 
@@ -141,7 +142,8 @@ actor SessionStateManager {
                 )
                 updateSubagents(sessionId: sessionId, subagents: subagents)
             } catch {
-                markFileReadError(sessionId: sessionId, now: now)
+                let reason = FileReadErrorReason(from: error)
+                markFileReadError(sessionId: sessionId, now: now, reason: reason)
             }
         }
 
@@ -156,6 +158,8 @@ actor SessionStateManager {
         let now = clock()
         let projectName = URL(fileURLWithPath: cwd).lastPathComponent
         let sessionId = "\(proc.pid)-\(proc.tty)"
+
+        guard !dismissedSessionIds.contains(sessionId) else { return }
 
         let info = SessionInfo(
             id: sessionId,
@@ -212,7 +216,7 @@ actor SessionStateManager {
         let newStatus: SessionStatus
         if session.info.status == .idle && snapshot.lastModified > session.enteredCurrentStatusAt {
             newStatus = .running
-        } else if session.info.status == .fileReadError {
+        } else if case .fileReadError = session.info.status {
             newStatus = .running
         } else {
             newStatus = session.info.status
@@ -263,18 +267,27 @@ actor SessionStateManager {
         managed[sessionId] = session
     }
 
-    private func markFileReadError(sessionId: String, now: Date) {
+    private func markFileReadError(sessionId: String, now: Date, reason: FileReadErrorReason) {
         guard var session = managed[sessionId] else { return }
 
         // Only transition to fileReadError from running or idle
         switch session.info.status {
         case .running, .idle:
-            session.info = rebuildInfo(session.info, status: .fileReadError, lastUpdated: now)
+            session.info = rebuildInfo(session.info, status: .fileReadError(reason: reason), lastUpdated: now)
             session.enteredCurrentStatusAt = now
             managed[sessionId] = session
         default:
             break
         }
+    }
+
+    func dismissSession(sessionId: String) async {
+        if let session = managed[sessionId] {
+            pidToSessionId.removeValue(forKey: session.info.pid)
+        }
+        dismissedSessionIds.insert(sessionId)
+        managed.removeValue(forKey: sessionId)
+        await pushToStore()
     }
 
     private func checkIdleTransitions(alivePids: Set<Int>) {

--- a/ClaudeMonitor/Sources/ClaudeMonitor/Presentation/DetailPanelView.swift
+++ b/ClaudeMonitor/Sources/ClaudeMonitor/Presentation/DetailPanelView.swift
@@ -3,7 +3,8 @@ import SwiftUI
 struct DetailPanelView: View {
     let sessions: [SessionInfo]
     let selection: SessionListViewModel.Selection?
-    let onOpenInFinder: (SessionInfo) -> Void
+    var onOpenInFinder: ((SessionInfo) -> Void)?
+    var onDismissSession: ((SessionInfo) -> Void)?
 
     var body: some View {
         Group {
@@ -49,7 +50,7 @@ struct DetailPanelView: View {
                 Spacer()
 
                 Button("Finder에서 보기") {
-                    onOpenInFinder(session)
+                    onOpenInFinder?(session)
                 }
                 .buttonStyle(.plain)
                 .font(.caption)
@@ -72,12 +73,10 @@ struct DetailPanelView: View {
                 subagentSummary(subagents: session.subagents)
             }
 
-            // Last assistant text
-            if session.status == .fileReadError {
+            // Last assistant text or error detail
+            if case .fileReadError(let reason) = session.status {
                 Divider().padding(.vertical, 4)
-                Text("데이터 읽기 실패")
-                    .font(.caption)
-                    .foregroundStyle(.red)
+                fileReadErrorSection(reason: reason, session: session)
             } else if !session.lastAssistantText.isEmpty {
                 Divider().padding(.vertical, 4)
                 lastAssistantTextSection(text: session.lastAssistantText)
@@ -204,12 +203,44 @@ struct DetailPanelView: View {
             )
     }
 
+    private func fileReadErrorSection(reason: FileReadErrorReason, session: SessionInfo) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Label("데이터 읽기 실패", systemImage: "exclamationmark.triangle.fill")
+                .font(.caption)
+                .foregroundStyle(.red)
+
+            Text(errorDescription(for: reason))
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+
+            Button(role: .destructive) {
+                onDismissSession?(session)
+            } label: {
+                Label("세션 제거", systemImage: "trash")
+            }
+            .buttonStyle(.plain)
+            .font(.caption)
+            .foregroundStyle(.red)
+        }
+    }
+
+    private func errorDescription(for reason: FileReadErrorReason) -> String {
+        switch reason {
+        case .noJsonlFile: "세션 데이터 파일을 찾을 수 없습니다"
+        case .noAssistantMessage: "응답 메시지가 없습니다"
+        case .encodingError: "파일 인코딩 오류"
+        case .pathViolation: "경로 접근이 차단되었습니다"
+        case .unknown: "알 수 없는 오류"
+        }
+    }
+
     private func statusColor(for status: SessionStatus) -> Color {
         switch status {
         case .running: .green
         case .idle: .yellow
         case .completed: .gray
-        case .error, .fileReadError: .red
+        case .error: .red
+        case .fileReadError: .orange
         }
     }
 
@@ -219,7 +250,7 @@ struct DetailPanelView: View {
         case .idle: "idle"
         case .completed: "completed"
         case .error: "error"
-        case .fileReadError: "error"
+        case .fileReadError: "file error"
         }
     }
 

--- a/ClaudeMonitor/Sources/ClaudeMonitor/Presentation/MainWindowView.swift
+++ b/ClaudeMonitor/Sources/ClaudeMonitor/Presentation/MainWindowView.swift
@@ -87,6 +87,9 @@ struct MainWindowView: View {
                 selection: selection,
                 onOpenInFinder: { session in
                     viewModel.openInFinder(session: session)
+                },
+                onDismissSession: { session in
+                    viewModel.dismissSession(session)
                 }
             )
         }

--- a/ClaudeMonitor/Sources/ClaudeMonitor/Presentation/PopoverView.swift
+++ b/ClaudeMonitor/Sources/ClaudeMonitor/Presentation/PopoverView.swift
@@ -87,6 +87,9 @@ struct PopoverView: View {
                 selection: viewModel.selection,
                 onOpenInFinder: { session in
                     viewModel.openInFinder(session: session)
+                },
+                onDismissSession: { session in
+                    viewModel.dismissSession(session)
                 }
             )
         }

--- a/ClaudeMonitor/Sources/ClaudeMonitor/Presentation/SessionCardView.swift
+++ b/ClaudeMonitor/Sources/ClaudeMonitor/Presentation/SessionCardView.swift
@@ -21,7 +21,7 @@ struct SessionCardView: View {
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
 
-                if session.status == .fileReadError {
+                if case .fileReadError = session.status {
                     Text("데이터 읽기 실패")
                         .font(.caption)
                         .foregroundStyle(.red)
@@ -46,7 +46,8 @@ struct SessionCardView: View {
         case .running: .green
         case .idle: .yellow
         case .completed: .gray
-        case .error, .fileReadError: .red
+        case .error: .red
+        case .fileReadError: .orange
         }
     }
 }

--- a/ClaudeMonitor/Sources/ClaudeMonitor/Presentation/SessionListViewModel.swift
+++ b/ClaudeMonitor/Sources/ClaudeMonitor/Presentation/SessionListViewModel.swift
@@ -10,6 +10,7 @@ enum AppStatus: Sendable {
 @Observable
 final class SessionListViewModel {
     private let store: SessionStore
+    private let stateManager: SessionStateManager
 
     enum Selection: Hashable {
         case session(id: String)
@@ -18,8 +19,9 @@ final class SessionListViewModel {
 
     var selection: Selection?
 
-    init(store: SessionStore) {
+    init(store: SessionStore, stateManager: SessionStateManager) {
         self.store = store
+        self.stateManager = stateManager
     }
 
     var sessions: [SessionInfo] {
@@ -40,8 +42,19 @@ final class SessionListViewModel {
     var hasError: Bool {
         store.sessions.contains { session in
             session.status == .error
-                || session.status == .fileReadError
+                || isFileReadError(session.status)
                 || session.subagents.contains { $0.status == .error }
+        }
+    }
+
+    private func isFileReadError(_ status: SessionStatus) -> Bool {
+        if case .fileReadError = status { return true }
+        return false
+    }
+
+    func dismissSession(_ session: SessionInfo) {
+        Task {
+            await stateManager.dismissSession(sessionId: session.id)
         }
     }
 

--- a/ClaudeMonitor/Sources/ClaudeMonitor/Presentation/SessionTreeView.swift
+++ b/ClaudeMonitor/Sources/ClaudeMonitor/Presentation/SessionTreeView.swift
@@ -156,7 +156,8 @@ struct SessionTreeView: View {
         case .running: .green
         case .idle: .yellow
         case .completed: .gray
-        case .error, .fileReadError: .red
+        case .error: .red
+        case .fileReadError: .orange
         }
     }
 
@@ -165,7 +166,8 @@ struct SessionTreeView: View {
         case .running: "circle.fill"
         case .idle: "pause.circle.fill"
         case .completed: "checkmark.circle.fill"
-        case .error, .fileReadError: "exclamationmark.circle.fill"
+        case .error: "exclamationmark.circle.fill"
+        case .fileReadError: "exclamationmark.triangle.fill"
         }
     }
 

--- a/ClaudeMonitor/Sources/ClaudeMonitor/Presentation/StatusDotView.swift
+++ b/ClaudeMonitor/Sources/ClaudeMonitor/Presentation/StatusDotView.swift
@@ -18,7 +18,7 @@ struct StatusDotView: View {
     private var dotColor: Color {
         switch status {
         case .monitoring: .green
-        case .idle: .secondary
+        case .idle: .orange
         case .error: .red
         }
     }

--- a/ClaudeMonitor/Tests/ClaudeMonitorTests/SessionStateManagerTests.swift
+++ b/ClaudeMonitor/Tests/ClaudeMonitorTests/SessionStateManagerTests.swift
@@ -299,7 +299,7 @@ struct SessionStateManagerTests {
 
         let sessions = await store.sessions
         #expect(sessions.count == 1)
-        #expect(sessions[0].status == .fileReadError)
+        #expect(sessions[0].status == .fileReadError(reason: .noJsonlFile))
     }
 
     // TC-SSM-08: fileReadError → running on successful read
@@ -324,7 +324,7 @@ struct SessionStateManagerTests {
         await manager.pollFilesOnce()
 
         var sessions = await store.sessions
-        #expect(sessions[0].status == .fileReadError)
+        #expect(sessions[0].status == .fileReadError(reason: .noJsonlFile))
 
         // Second: succeed
         await fileReader.setResult(for: projectDir, result: .success(makeSnapshot()))


### PR DESCRIPTION
## Summary
- Footer StatusDotView idle 색상을 `.secondary` → `.orange`로 변경하여 가시성 확보
- `SessionStatus.fileReadError`에 `FileReadErrorReason` 연관값 추가로 에러 원인 보존 및 표시
- `SessionStateManager`에 `dismissSession` 메서드 추가 — 사용자가 fileReadError 세션을 목록에서 제거 가능
- `DetailPanelView`에 에러 원인 한국어 설명 + "세션 제거" 버튼 추가
- `SessionTreeView`에서 fileReadError(경고 삼각형) / error(오류 원형) 아이콘 구분

## Test plan
- [x] 47개 기존 테스트 통과 (SessionStatus 변경 대응 완료)
- [ ] 앱 실행 후 idle 상태에서 orange 점 표시 확인
- [ ] fileReadError 세션 선택 시 에러 원인 메시지 표시 확인
- [ ] "세션 제거" 버튼 클릭 시 세션 목록에서 즉시 제거 확인
- [ ] dismiss된 세션이 다시 나타나지 않는 것 확인

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)