### PR TITLE
fix: 세션/서브에이전트 응답 텍스트 잘림 수정 (5000자 + truncation 안내)

### DIFF
--- a/ClaudeMonitor/Sources/ClaudeMonitor/Domain/Models/SessionInfo.swift
+++ b/ClaudeMonitor/Sources/ClaudeMonitor/Domain/Models/SessionInfo.swift
@@ -10,6 +10,7 @@ struct SessionSnapshot: Sendable, Hashable {
     let sessionId: String
     let gitBranch: String
     let lastAssistantText: String
+    let isTextTruncated: Bool
     let lastModified: Date
     let hasError: Bool
 }
@@ -22,6 +23,7 @@ struct SessionInfo: Identifiable, Sendable, Hashable {
     let projectPath: URL
     let gitBranch: String
     let lastAssistantText: String
+    let isTextTruncated: Bool
     let status: SessionStatus
     let lastUpdated: Date
     let subagents: [SubagentInfo]

--- a/ClaudeMonitor/Sources/ClaudeMonitor/Domain/Models/SubagentInfo.swift
+++ b/ClaudeMonitor/Sources/ClaudeMonitor/Domain/Models/SubagentInfo.swift
@@ -5,6 +5,7 @@ struct SubagentInfo: Identifiable, Sendable, Hashable {
     let agentType: String
     let parentSessionId: String
     let lastAssistantText: String
+    let isTextTruncated: Bool
     let lastUpdated: Date
     let status: SessionStatus
 }

--- a/ClaudeMonitor/Sources/ClaudeMonitor/Domain/SessionStateManager.swift
+++ b/ClaudeMonitor/Sources/ClaudeMonitor/Domain/SessionStateManager.swift
@@ -169,6 +169,7 @@ actor SessionStateManager {
             projectPath: URL(fileURLWithPath: cwd),
             gitBranch: "unknown",
             lastAssistantText: "",
+            isTextTruncated: false,
             status: .running,
             lastUpdated: now,
             subagents: []
@@ -232,6 +233,7 @@ actor SessionStateManager {
             projectPath: session.info.projectPath,
             gitBranch: snapshot.gitBranch,
             lastAssistantText: snapshot.lastAssistantText,
+            isTextTruncated: snapshot.isTextTruncated,
             status: newStatus,
             lastUpdated: now,
             subagents: session.info.subagents
@@ -256,6 +258,7 @@ actor SessionStateManager {
             projectPath: session.info.projectPath,
             gitBranch: session.info.gitBranch,
             lastAssistantText: session.info.lastAssistantText,
+            isTextTruncated: session.info.isTextTruncated,
             status: session.info.status,
             lastUpdated: session.info.lastUpdated,
             subagents: subagents
@@ -348,6 +351,7 @@ actor SessionStateManager {
             projectPath: info.projectPath,
             gitBranch: info.gitBranch,
             lastAssistantText: info.lastAssistantText,
+            isTextTruncated: info.isTextTruncated,
             status: status,
             lastUpdated: lastUpdated,
             subagents: info.subagents

--- a/ClaudeMonitor/Sources/ClaudeMonitor/Infrastructure/SessionFileReader.swift
+++ b/ClaudeMonitor/Sources/ClaudeMonitor/Infrastructure/SessionFileReader.swift
@@ -106,13 +106,17 @@ actor SessionFileReader: SessionFileReaderProtocol {
             else { continue }
 
             let lastAssistantText: String
+            let isTextTruncated: Bool
             if let content = message["content"] as? [[String: Any]] {
                 let texts = content
                     .filter { $0["type"] as? String == "text" }
                     .compactMap { $0["text"] as? String }
-                lastAssistantText = String(texts.joined(separator: " ").prefix(100))
+                let joined = texts.joined(separator: " ")
+                isTextTruncated = joined.count > 5000
+                lastAssistantText = String(joined.prefix(5000))
             } else {
                 lastAssistantText = ""
+                isTextTruncated = false
             }
 
             let stopReason = json["stop_reason"] as? String
@@ -126,6 +130,7 @@ actor SessionFileReader: SessionFileReaderProtocol {
                 sessionId: sessionId ?? "unknown",
                 gitBranch: gitBranch ?? "unknown",
                 lastAssistantText: lastAssistantText,
+                isTextTruncated: isTextTruncated,
                 lastModified: lastModified,
                 hasError: hasError
             )

--- a/ClaudeMonitor/Sources/ClaudeMonitor/Infrastructure/SubagentFileReader.swift
+++ b/ClaudeMonitor/Sources/ClaudeMonitor/Infrastructure/SubagentFileReader.swift
@@ -98,6 +98,7 @@ actor SubagentFileReader {
 
         var parentSessionId: String?
         var lastAssistantText: String = ""
+        var isTextTruncated = false
         var lastUpdated: Date?
         var foundAssistant = false
         var hasError = false
@@ -131,7 +132,9 @@ actor SubagentFileReader {
                 let texts = content
                     .filter { $0["type"] as? String == "text" }
                     .compactMap { $0["text"] as? String }
-                lastAssistantText = String(texts.joined(separator: " ").prefix(500))
+                let joined = texts.joined(separator: " ")
+                isTextTruncated = joined.count > 5000
+                lastAssistantText = String(joined.prefix(5000))
             }
             foundAssistant = true
         }
@@ -153,6 +156,7 @@ actor SubagentFileReader {
             agentType: agentType,
             parentSessionId: parentSessionId ?? "unknown",
             lastAssistantText: lastAssistantText,
+            isTextTruncated: isTextTruncated,
             lastUpdated: lastUpdated ?? fileDate,
             status: status
         )

--- a/ClaudeMonitor/Sources/ClaudeMonitor/Presentation/DetailPanelView.swift
+++ b/ClaudeMonitor/Sources/ClaudeMonitor/Presentation/DetailPanelView.swift
@@ -79,7 +79,7 @@ struct DetailPanelView: View {
                 fileReadErrorSection(reason: reason, session: session)
             } else if !session.lastAssistantText.isEmpty {
                 Divider().padding(.vertical, 4)
-                lastAssistantTextSection(text: session.lastAssistantText)
+                lastAssistantTextSection(text: session.lastAssistantText, isTruncated: session.isTextTruncated)
             }
         }
     }
@@ -109,14 +109,14 @@ struct DetailPanelView: View {
             // Last assistant text
             if !agent.lastAssistantText.isEmpty {
                 Divider().padding(.vertical, 4)
-                lastAssistantTextSection(text: agent.lastAssistantText)
+                lastAssistantTextSection(text: agent.lastAssistantText, isTruncated: agent.isTextTruncated)
             }
         }
     }
 
     // MARK: - Last Assistant Text
 
-    private func lastAssistantTextSection(text: String) -> some View {
+    private func lastAssistantTextSection(text: String, isTruncated: Bool = false) -> some View {
         VStack(alignment: .leading, spacing: 4) {
             Text("마지막 응답")
                 .font(.caption2)
@@ -124,11 +124,20 @@ struct DetailPanelView: View {
                 .foregroundStyle(.secondary)
 
             ScrollView {
-                Text(text)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(10)
+                VStack(alignment: .leading, spacing: 0) {
+                    Text(text)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+
+                    if isTruncated {
+                        Divider().padding(.vertical, 6)
+                        Text("내용이 너무 길어 일부만 표시됩니다.")
+                            .font(.caption2)
+                            .foregroundStyle(.orange)
+                    }
+                }
+                .padding(10)
             }
             .background(
                 RoundedRectangle(cornerRadius: 8)

--- a/ClaudeMonitor/Tests/ClaudeMonitorTests/SessionFileReaderTests.swift
+++ b/ClaudeMonitor/Tests/ClaudeMonitorTests/SessionFileReaderTests.swift
@@ -76,11 +76,11 @@ struct SessionFileReaderTests {
         }
     }
 
-    // TC-10: prefix(100) applied
-    @Test("lastAssistantText truncated to 100 chars")
+    // TC-10: prefix(5000) applied
+    @Test("lastAssistantText truncated to 5000 chars")
     func prefixTruncation() async throws {
         let (projectDir, reader) = try setupProjectDir()
-        let longText = String(repeating: "a", count: 200)
+        let longText = String(repeating: "a", count: 8000)
         let content = """
         {"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"\(longText)"}]},"stop_reason":"end_turn","sessionId":"s1","gitBranch":"main"}
         """
@@ -88,7 +88,8 @@ struct SessionFileReaderTests {
         try content.write(to: file, atomically: true, encoding: .utf8)
 
         let snapshot = try await reader.readLatestSession(projectDirectory: projectDir)
-        #expect(snapshot.lastAssistantText.count == 100)
+        #expect(snapshot.lastAssistantText.count == 5000)
+        #expect(snapshot.isTextTruncated == true)
     }
 
     // TC-11: stop_reason != end_turn → hasError

--- a/ClaudeMonitor/Tests/ClaudeMonitorTests/SessionStateManagerTests.swift
+++ b/ClaudeMonitor/Tests/ClaudeMonitorTests/SessionStateManagerTests.swift
@@ -121,6 +121,7 @@ struct SessionStateManagerTests {
         sessionId: String = "test-session",
         gitBranch: String = "main",
         lastAssistantText: String = "Working on task",
+        isTextTruncated: Bool = false,
         lastModified: Date = Date(),
         hasError: Bool = false
     ) -> SessionSnapshot {
@@ -128,6 +129,7 @@ struct SessionStateManagerTests {
             sessionId: sessionId,
             gitBranch: gitBranch,
             lastAssistantText: lastAssistantText,
+            isTextTruncated: isTextTruncated,
             lastModified: lastModified,
             hasError: hasError
         )

--- a/ClaudeMonitor/Tests/ClaudeMonitorTests/SubagentFileReaderTests.swift
+++ b/ClaudeMonitor/Tests/ClaudeMonitorTests/SubagentFileReaderTests.swift
@@ -142,13 +142,13 @@ struct SubagentFileReaderTests {
         #expect(results[0].agentType == "unknown")
     }
 
-    // lastAssistantText prefix(500) 적용
-    @Test("lastAssistantText truncated to 500 characters")
+    // lastAssistantText prefix(5000) 적용
+    @Test("lastAssistantText truncated to 5000 characters")
     func textTruncation() async throws {
         let (sessionDir, reader) = try setupSessionDir()
         let subDir = try createSubagentsDir(in: sessionDir)
 
-        let longText = String(repeating: "a", count: 1000)
+        let longText = String(repeating: "a", count: 8000)
         let content = """
         {"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"\(longText)"}]},"stop_reason":"end_turn","sessionId":"s1","timestamp":"2026-03-08T10:00:00Z"}
         """
@@ -157,7 +157,8 @@ struct SubagentFileReaderTests {
 
         let results = await reader.readSubagents(sessionDirectory: sessionDir)
         #expect(results.count == 1)
-        #expect(results[0].lastAssistantText.count == 500)
+        #expect(results[0].lastAssistantText.count == 5000)
+        #expect(results[0].isTextTruncated == true)
     }
 
     // 복수 서브에이전트 파싱


### PR DESCRIPTION
## Summary
- 메인 세션 lastAssistantText 제한: 100자 → 5000자
- 서브에이전트 lastAssistantText 제한: 500자 → 5000자
- `isTextTruncated` 플래그 추가 (SessionSnapshot, SessionInfo, SubagentInfo)
- DetailPanelView에서 잘린 경우 "내용이 너무 길어 일부만 표시됩니다" 안내 표시 (orange 색상)

## Test plan
- [x] 47개 테스트 통과 (truncation 테스트 5000자 기준으로 업데이트)
- [ ] 긴 응답을 가진 세션에서 5000자까지 표시 확인
- [ ] 5000자 초과 시 truncation 안내 메시지 표시 확인

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)