### PR TITLE
텍스트 제한 5000자 → 2000자로 축소 (성능 개선)

### DIFF
--- a/ClaudeMonitor/Sources/ClaudeMonitor/Infrastructure/SessionFileReader.swift
+++ b/ClaudeMonitor/Sources/ClaudeMonitor/Infrastructure/SessionFileReader.swift
@@ -112,8 +112,8 @@ actor SessionFileReader: SessionFileReaderProtocol {
                     .filter { $0["type"] as? String == "text" }
                     .compactMap { $0["text"] as? String }
                 let joined = texts.joined(separator: " ")
-                isTextTruncated = joined.count > 5000
-                lastAssistantText = String(joined.prefix(5000))
+                isTextTruncated = joined.count > 2000
+                lastAssistantText = String(joined.prefix(2000))
             } else {
                 lastAssistantText = ""
                 isTextTruncated = false

--- a/ClaudeMonitor/Sources/ClaudeMonitor/Infrastructure/SubagentFileReader.swift
+++ b/ClaudeMonitor/Sources/ClaudeMonitor/Infrastructure/SubagentFileReader.swift
@@ -133,8 +133,8 @@ actor SubagentFileReader {
                     .filter { $0["type"] as? String == "text" }
                     .compactMap { $0["text"] as? String }
                 let joined = texts.joined(separator: " ")
-                isTextTruncated = joined.count > 5000
-                lastAssistantText = String(joined.prefix(5000))
+                isTextTruncated = joined.count > 2000
+                lastAssistantText = String(joined.prefix(2000))
             }
             foundAssistant = true
         }

--- a/ClaudeMonitor/Tests/ClaudeMonitorTests/SessionFileReaderTests.swift
+++ b/ClaudeMonitor/Tests/ClaudeMonitorTests/SessionFileReaderTests.swift
@@ -76,11 +76,11 @@ struct SessionFileReaderTests {
         }
     }
 
-    // TC-10: prefix(5000) applied
-    @Test("lastAssistantText truncated to 5000 chars")
+    // TC-10: prefix(2000) applied
+    @Test("lastAssistantText truncated to 2000 chars")
     func prefixTruncation() async throws {
         let (projectDir, reader) = try setupProjectDir()
-        let longText = String(repeating: "a", count: 8000)
+        let longText = String(repeating: "a", count: 5000)
         let content = """
         {"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"\(longText)"}]},"stop_reason":"end_turn","sessionId":"s1","gitBranch":"main"}
         """
@@ -88,7 +88,7 @@ struct SessionFileReaderTests {
         try content.write(to: file, atomically: true, encoding: .utf8)
 
         let snapshot = try await reader.readLatestSession(projectDirectory: projectDir)
-        #expect(snapshot.lastAssistantText.count == 5000)
+        #expect(snapshot.lastAssistantText.count == 2000)
         #expect(snapshot.isTextTruncated == true)
     }
 

--- a/ClaudeMonitor/Tests/ClaudeMonitorTests/SubagentFileReaderTests.swift
+++ b/ClaudeMonitor/Tests/ClaudeMonitorTests/SubagentFileReaderTests.swift
@@ -142,13 +142,13 @@ struct SubagentFileReaderTests {
         #expect(results[0].agentType == "unknown")
     }
 
-    // lastAssistantText prefix(5000) 적용
-    @Test("lastAssistantText truncated to 5000 characters")
+    // lastAssistantText prefix(2000) 적용
+    @Test("lastAssistantText truncated to 2000 characters")
     func textTruncation() async throws {
         let (sessionDir, reader) = try setupSessionDir()
         let subDir = try createSubagentsDir(in: sessionDir)
 
-        let longText = String(repeating: "a", count: 8000)
+        let longText = String(repeating: "a", count: 5000)
         let content = """
         {"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"\(longText)"}]},"stop_reason":"end_turn","sessionId":"s1","timestamp":"2026-03-08T10:00:00Z"}
         """
@@ -157,7 +157,7 @@ struct SubagentFileReaderTests {
 
         let results = await reader.readSubagents(sessionDirectory: sessionDir)
         #expect(results.count == 1)
-        #expect(results[0].lastAssistantText.count == 5000)
+        #expect(results[0].lastAssistantText.count == 2000)
         #expect(results[0].isTextTruncated == true)
     }
 


### PR DESCRIPTION
## Summary
- 텍스트 제한을 5000자에서 2000자로 축소하여 UI 렌더링 딜레이 해결
- SessionFileReader, SubagentFileReader 양쪽 동일 적용
- 테스트 기대값 업데이트 (47개 전체 통과)

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)