### PR TITLE
macOS Dock에 앱 실행 상태 표시

### DIFF
--- a/ClaudeMonitor/Sources/ClaudeMonitor/App/AppDelegate.swift
+++ b/ClaudeMonitor/Sources/ClaudeMonitor/App/AppDelegate.swift
@@ -26,6 +26,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
+    func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
+        menuBarController?.togglePopover()
+        return false
+    }
+
     func applicationWillTerminate(_ notification: Notification) {
         let mgr = manager
         Task { await mgr?.stop() }

--- a/ClaudeMonitor/Sources/ClaudeMonitor/App/Info.plist
+++ b/ClaudeMonitor/Sources/ClaudeMonitor/App/Info.plist
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>LSUIElement</key>
-    <true/>
     <key>CFBundleShortVersionString</key>
     <string>1.0</string>
     <key>CFBundleVersion</key>

--- a/ClaudeMonitor/Sources/ClaudeMonitor/Presentation/MenuBarController.swift
+++ b/ClaudeMonitor/Sources/ClaudeMonitor/Presentation/MenuBarController.swift
@@ -45,7 +45,7 @@ final class MenuBarController {
         startObserving()
     }
 
-    @objc private func togglePopover() {
+    @objc func togglePopover() {
         guard let button = statusItem?.button else { return }
 
         if popover.isShown {
@@ -77,6 +77,18 @@ final class MenuBarController {
         }
 
         button.contentTintColor = color
+        updateDockBadge()
+    }
+
+    private func updateDockBadge() {
+        let dockTile = NSApp.dockTile
+        if viewModel.hasError {
+            dockTile.badgeLabel = "!"
+        } else if viewModel.activeCount > 0 {
+            dockTile.badgeLabel = "\(viewModel.activeCount)"
+        } else {
+            dockTile.badgeLabel = nil
+        }
     }
 
     private func startObserving() {


### PR DESCRIPTION
## Summary
- LSUIElement 제거하여 Dock 아이콘 표시
- Dock 배지로 활성 세션 수 표시 (에러 시 "!" 표시)
- Dock 아이콘 클릭 시 메뉴바 팝오버 토글
- 메뉴바 아이콘 기존 동작 유지

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)