### PR TITLE
세션 제거 상태 영구 저장 (UserDefaults)

### DIFF
--- a/ClaudeMonitor/Sources/ClaudeMonitor/Domain/SessionStateManager.swift
+++ b/ClaudeMonitor/Sources/ClaudeMonitor/Domain/SessionStateManager.swift
@@ -24,7 +24,9 @@ actor SessionStateManager {
     private var pendingRemovals: [PendingRemoval] = []
     private var previousPids: Set<Int> = []
     private var pidToSessionId: [Int: String] = [:]
-    private var dismissedSessionIds: Set<String> = []
+    private var dismissedSessionIds: Set<String> {
+        didSet { Self.saveDismissedIds(dismissedSessionIds) }
+    }
     private var processTask: Task<Void, Never>?
     private var fileTask: Task<Void, Never>?
 
@@ -50,6 +52,7 @@ actor SessionStateManager {
         self.processInterval = processInterval
         self.fileInterval = fileInterval
         self.idleThreshold = idleThreshold
+        self.dismissedSessionIds = Self.loadDismissedIds()
     }
 
     deinit {
@@ -356,6 +359,19 @@ actor SessionStateManager {
             lastUpdated: lastUpdated,
             subagents: info.subagents
         )
+    }
+
+    // MARK: - Persistence
+
+    private static let dismissedKey = "dismissedSessionIds"
+
+    private nonisolated static func loadDismissedIds() -> Set<String> {
+        let array = UserDefaults.standard.stringArray(forKey: dismissedKey) ?? []
+        return Set(array)
+    }
+
+    private nonisolated static func saveDismissedIds(_ ids: Set<String>) {
+        UserDefaults.standard.set(Array(ids), forKey: dismissedKey)
     }
 
     // MARK: - Test Helpers


### PR DESCRIPTION
## Summary
- dismissedSessionIds를 UserDefaults에 영구 저장
- 앱 재시작 시에도 제거한 세션이 다시 나타나지 않음

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)