### PR TITLE
fix: 초기 로딩 완료 조건을 프로세스+파일 폴링 양쪽 완료로 변경

### DIFF
--- a/ClaudeMonitor/Sources/ClaudeMonitor/Domain/SessionStateManager.swift
+++ b/ClaudeMonitor/Sources/ClaudeMonitor/Domain/SessionStateManager.swift
@@ -24,6 +24,8 @@ actor SessionStateManager {
     private var pendingRemovals: [PendingRemoval] = []
     private var previousPids: Set<Int> = []
     private var pidToSessionId: [Int: String] = [:]
+    private var processPolledOnce = false
+    private var filePolledOnce = false
     private var dismissedSessionIds: Set<String> {
         didSet { Self.saveDismissedIds(dismissedSessionIds) }
     }
@@ -112,7 +114,7 @@ actor SessionStateManager {
 
         previousPids = currentPids
         await pushToStore()
-        await markInitialLoadComplete()
+        await markProcessPolledOnce()
     }
 
     // MARK: - File Polling
@@ -152,6 +154,7 @@ actor SessionStateManager {
         }
 
         await pushToStore()
+        await markFilePolledOnce()
     }
 
     // MARK: - Session Management
@@ -344,7 +347,18 @@ actor SessionStateManager {
         }
     }
 
-    private func markInitialLoadComplete() async {
+    private func markProcessPolledOnce() async {
+        processPolledOnce = true
+        await flushInitialLoadIfReady()
+    }
+
+    private func markFilePolledOnce() async {
+        filePolledOnce = true
+        await flushInitialLoadIfReady()
+    }
+
+    private func flushInitialLoadIfReady() async {
+        guard processPolledOnce && filePolledOnce else { return }
         await MainActor.run {
             if sessionStore.isInitialLoading {
                 sessionStore.isInitialLoading = false

--- a/ClaudeMonitor/Tests/ClaudeMonitorTests/SessionStateManagerTests.swift
+++ b/ClaudeMonitor/Tests/ClaudeMonitorTests/SessionStateManagerTests.swift
@@ -434,4 +434,88 @@ struct SessionStateManagerTests {
         let sessions = await store.sessions
         #expect(sessions.count == 3)
     }
+
+    // TC-SSM-13: isInitialLoading remains true after only process poll
+    @Test("isInitialLoading remains true after only process poll (AC-1, AC-2)")
+    func isInitialLoadingRemainsAfterProcessPollOnly() async {
+        let scanner = MockProcessScanner()
+        let (manager, store, _, _, _) = await makeSut(scanner: scanner)
+
+        await scanner.setScanResults([[makeProc()]])
+        await manager.pollProcessesOnce()
+
+        let loading = await store.isInitialLoading
+        #expect(loading == true, "isInitialLoading should remain true until file poll completes")
+    }
+
+    // TC-SSM-14: isInitialLoading becomes false after both polls complete
+    @Test("isInitialLoading becomes false after both polls complete (AC-3)")
+    func isInitialLoadingFalseAfterBothPolls() async {
+        let scanner = MockProcessScanner()
+        let fileReader = MockSessionFileReader()
+        let (manager, store, _, _, _) = await makeSut(scanner: scanner, fileReader: fileReader)
+
+        let proc = makeProc()
+        await scanner.setScanResults([[proc]])
+
+        let pathEncoder = makePathEncoder()
+        if let projectDir = pathEncoder.projectDirectory(for: proc.cwd!) {
+            await fileReader.setResult(
+                for: projectDir,
+                result: .success(makeSnapshot())
+            )
+        }
+
+        await manager.pollProcessesOnce()
+        await manager.pollFilesOnce()
+
+        let loading = await store.isInitialLoading
+        #expect(loading == false, "isInitialLoading should be false after both polls complete")
+    }
+
+    // TC-SSM-15: isInitialLoading stays false after subsequent polls (AC-4)
+    @Test("isInitialLoading stays false after subsequent polls (AC-4)")
+    func isInitialLoadingStaysFalseAfterSubsequentPolls() async {
+        let scanner = MockProcessScanner()
+        let fileReader = MockSessionFileReader()
+        let (manager, store, _, _, _) = await makeSut(scanner: scanner, fileReader: fileReader)
+
+        let proc = makeProc()
+        await scanner.setScanResults([[proc], [proc]])
+
+        let pathEncoder = makePathEncoder()
+        if let projectDir = pathEncoder.projectDirectory(for: proc.cwd!) {
+            await fileReader.setResult(
+                for: projectDir,
+                result: .success(makeSnapshot())
+            )
+        }
+
+        // Initial polls
+        await manager.pollProcessesOnce()
+        await manager.pollFilesOnce()
+
+        // Subsequent polls
+        await manager.pollProcessesOnce()
+        await manager.pollFilesOnce()
+
+        let loading = await store.isInitialLoading
+        #expect(loading == false, "isInitialLoading should stay false after subsequent polls")
+    }
+
+    // TC-SSM-16: Empty state shows correctly when no Claude processes (AC-5)
+    @Test("Empty state after both polls with no processes (AC-5)")
+    func emptyStateAfterBothPollsNoProcesses() async {
+        let scanner = MockProcessScanner()
+        let (manager, store, _, _, _) = await makeSut(scanner: scanner)
+
+        await scanner.setScanResults([[]])
+        await manager.pollProcessesOnce()
+        await manager.pollFilesOnce()
+
+        let loading = await store.isInitialLoading
+        let sessions = await store.sessions
+        #expect(loading == false, "isInitialLoading should be false after both polls")
+        #expect(sessions.isEmpty, "Sessions should be empty with no processes")
+    }
 }


### PR DESCRIPTION
## Summary
- 앱 초기 로딩 시 프로세스 폴링만 완료되면 `isInitialLoading`이 해제되어 불완전한 세션 카드가 잠시 표시되던 버그 수정
- `processPolledOnce`/`filePolledOnce` 두 플래그를 도입하여 양쪽 모두 완료된 시점에만 로딩 상태 해제
- AC-1~5 커버하는 테스트 4개 추가 (TC-SSM-13~16)

## Audit Summary
- **QA**: PASS (AC-1~5 전부 통과)
- **UX**: CONDITIONAL (전환 애니메이션 부재 — 후속 개선)
- **ZT**: CONDITIONAL (정상 운용 범위 완화됨, 조기 해제 시나리오 잔존)

## Test plan
- [x] 51 tests passed (기존 47 + 신규 4)
- [x] 빌드 성공
- [x] 프로세스 폴링만 완료 시 `isInitialLoading` 유지 확인
- [x] 양쪽 완료 후 `isInitialLoading` 해제 확인
- [x] 후속 폴링 시 불변 확인
- [x] 프로세스 없을 때 빈 상태 정상 표시 확인

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)