### PR TITLE
fix: PathEncoder 언더스코어 인코딩 버그 수정

### DIFF
--- a/ClaudeMonitor/Sources/ClaudeMonitor/Infrastructure/PathEncoder.swift
+++ b/ClaudeMonitor/Sources/ClaudeMonitor/Infrastructure/PathEncoder.swift
@@ -12,7 +12,9 @@ struct PathEncoder: Sendable {
         let normalized = URL(fileURLWithPath: path).standardized.path
         let collapsed = normalized.split(separator: "/").joined(separator: "/")
         let withLeadingSlash = normalized.hasPrefix("/") ? "/" + collapsed : collapsed
-        return withLeadingSlash.replacingOccurrences(of: "/", with: "-")
+        return withLeadingSlash
+            .replacingOccurrences(of: "/", with: "-")
+            .replacingOccurrences(of: "_", with: "-")
     }
 
     func projectDirectory(for path: String) -> URL? {

--- a/ClaudeMonitor/Tests/ClaudeMonitorTests/PathEncoderTests.swift
+++ b/ClaudeMonitor/Tests/ClaudeMonitorTests/PathEncoderTests.swift
@@ -69,4 +69,27 @@ struct PathEncoderTests {
         let second = encoder.projectDirectory(for: "/Users/bombo/foo")
         #expect(first == second)
     }
+
+    // MARK: - 언더스코어 인코딩 (Issue #49)
+
+    @Test("TC-12: 언더스코어 단일 포함 경로")
+    func encodePathWithSingleUnderscore() {
+        #expect(encoder.encode(path: "/Users/bombo/my_project") == "-Users-bombo-my-project")
+    }
+
+    @Test("TC-13: 언더스코어 다중 포함 경로")
+    func encodePathWithMultipleUnderscores() {
+        #expect(encoder.encode(path: "/Users/bombo/Documents/000_PRIVATE/999_PROJECT/003-CLAUDE-MONITOR") == "-Users-bombo-Documents-000-PRIVATE-999-PROJECT-003-CLAUDE-MONITOR")
+    }
+
+    @Test("TC-14: 하이픈+언더스코어 혼합 경로")
+    func encodePathWithHyphenAndUnderscore() {
+        #expect(encoder.encode(path: "/Users/test/my-app_v2") == "-Users-test-my-app-v2")
+    }
+
+    @Test("TC-15: projectDirectory 언더스코어 경로 조합")
+    func projectDirectoryWithUnderscore() throws {
+        let result = try #require(encoder.projectDirectory(for: "/Users/bombo/my_project"))
+        #expect(result.path().hasSuffix(".claude/projects/-Users-bombo-my-project/"))
+    }
 }


### PR DESCRIPTION
## Summary
- PathEncoder.encode()에서 `_`를 `-`로 변환하도록 수정
- Claude CLI의 프로젝트 디렉토리 인코딩 규칙과 일치시킴
- 언더스코어 포함 경로 테스트 4개 추가 (TC-12~TC-15)

Closes #49

## Test plan
- [x] 기존 PathEncoder 테스트 11개 통과 확인
- [x] 신규 언더스코어 테스트 4개 통과 확인
- [x] 전체 테스트 51개 통과 확인
- [ ] 실제 언더스코어 경로 프로젝트에서 세션 데이터 정상 로드 확인

## Audit Summary
- QA: PASS (51/51 tests)
- AC: 4/4 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)