### PR TITLE
feat: 에러 감지 안정성 개선 및 트리뷰 에러 이유 표시

### DIFF
--- a/ClaudeMonitor/Sources/ClaudeMonitor/Domain/SessionStateManager.swift
+++ b/ClaudeMonitor/Sources/ClaudeMonitor/Domain/SessionStateManager.swift
@@ -7,7 +7,11 @@ actor SessionStateManager {
         let processInfo: ClaudeProcessInfo
         var enteredCurrentStatusAt: Date
         var hasError: Bool = false
+        var consecutiveFileReadFailures: Int = 0
+        var hasEverLoadedData: Bool = false
     }
+
+    static let fileReadErrorThreshold = 3
 
     private let sessionStore: SessionStore
     private let processScanner: any ProcessScannerProtocol
@@ -158,8 +162,14 @@ actor SessionStateManager {
     private func addSession(from proc: ClaudeProcessInfo) {
         guard let cwd = proc.cwd else { return }
 
+        // Skip if another session with the same project path already exists
+        // (subagent processes share the parent's cwd)
+        let projectPath = URL(fileURLWithPath: cwd)
+        let alreadyTracked = managed.values.contains { $0.info.projectPath == projectPath }
+        guard !alreadyTracked else { return }
+
         let now = clock()
-        let projectName = URL(fileURLWithPath: cwd).lastPathComponent
+        let projectName = projectPath.lastPathComponent
         let sessionId = "\(proc.pid)-\(proc.tty)"
 
         guard !dismissedSessionIds.contains(sessionId) else { return }
@@ -192,6 +202,13 @@ actor SessionStateManager {
         else { return }
 
         let now = clock()
+
+        // Sessions that never loaded data (e.g. subagent processes) — remove silently
+        if !session.hasEverLoadedData {
+            managed.removeValue(forKey: sessionId)
+            pidToSessionId.removeValue(forKey: pid)
+            return
+        }
 
         if session.hasError {
             session.info = rebuildInfo(session.info, status: .error, lastUpdated: now)
@@ -243,6 +260,8 @@ actor SessionStateManager {
         )
 
         session.hasError = snapshot.hasError
+        session.consecutiveFileReadFailures = 0
+        session.hasEverLoadedData = true
 
         if statusChanged {
             session.enteredCurrentStatusAt = now
@@ -277,9 +296,22 @@ actor SessionStateManager {
     private func markFileReadError(sessionId: String, now: Date, reason: FileReadErrorReason) {
         guard var session = managed[sessionId] else { return }
 
-        // Only transition to fileReadError from running or idle
+        session.consecutiveFileReadFailures += 1
+
+        // Never show fileReadError for sessions that have never loaded data
+        // (likely subagent processes without their own JSONL files)
+        guard session.hasEverLoadedData else {
+            managed[sessionId] = session
+            return
+        }
+
+        // Only transition to fileReadError after consecutive failures exceed threshold
         switch session.info.status {
         case .running, .idle:
+            guard session.consecutiveFileReadFailures >= Self.fileReadErrorThreshold else {
+                managed[sessionId] = session
+                return
+            }
             session.info = rebuildInfo(session.info, status: .fileReadError(reason: reason), lastUpdated: now)
             session.enteredCurrentStatusAt = now
             managed[sessionId] = session

--- a/ClaudeMonitor/Sources/ClaudeMonitor/Infrastructure/SessionFileReader.swift
+++ b/ClaudeMonitor/Sources/ClaudeMonitor/Infrastructure/SessionFileReader.swift
@@ -121,7 +121,9 @@ actor SessionFileReader: SessionFileReaderProtocol {
 
             let stopReason = json["stop_reason"] as? String
                 ?? (message["stop_reason"] as? String)
-            let hasError = (stopReason != nil) && (stopReason != "end_turn")
+            let hasError = (stopReason != nil)
+                && stopReason != "end_turn"
+                && stopReason != "tool_use"
 
             let attrs = try? FileManager.default.attributesOfItem(atPath: fileURL.path())
             let lastModified = (attrs?[.modificationDate] as? Date) ?? Date()
@@ -136,6 +138,18 @@ actor SessionFileReader: SessionFileReaderProtocol {
             )
         }
 
-        throw SessionFileError.noAssistantMessage
+        // No assistant message found in tail — return partial snapshot
+        // (common during heavy tool use when last 16KB has no assistant text)
+        let attrs = try? FileManager.default.attributesOfItem(atPath: fileURL.path())
+        let lastModified = (attrs?[.modificationDate] as? Date) ?? Date()
+
+        return SessionSnapshot(
+            sessionId: sessionId ?? "unknown",
+            gitBranch: gitBranch ?? "unknown",
+            lastAssistantText: "",
+            isTextTruncated: false,
+            lastModified: lastModified,
+            hasError: false
+        )
     }
 }

--- a/ClaudeMonitor/Sources/ClaudeMonitor/Infrastructure/SubagentFileReader.swift
+++ b/ClaudeMonitor/Sources/ClaudeMonitor/Infrastructure/SubagentFileReader.swift
@@ -102,7 +102,6 @@ actor SubagentFileReader {
         var lastUpdated: Date?
         var foundAssistant = false
         var hasError = false
-        var hasEndTurn = false
 
         for line in lines {
             guard let jsonData = line.data(using: .utf8),
@@ -120,9 +119,6 @@ actor SubagentFileReader {
             let stopReason = (json["message"] as? [String: Any])?["stop_reason"] as? String
             if stopReason != nil && stopReason != "end_turn" && stopReason != "tool_use" {
                 hasError = true
-            }
-            if stopReason == "end_turn" {
-                hasEndTurn = true
             }
 
             guard !foundAssistant else { continue }
@@ -146,13 +142,14 @@ actor SubagentFileReader {
         let attrs = try? FileManager.default.attributesOfItem(atPath: file.path())
         let fileDate = (attrs?[.modificationDate] as? Date) ?? Date()
 
+        let fileAge = Date().timeIntervalSince(fileDate)
+
         let status: SessionStatus
         if hasError {
             status = .error
-        } else if hasEndTurn, let updated = lastUpdated, Date().timeIntervalSince(updated) > 60 {
+        } else if fileAge > 60 {
+            // File not modified for 60s → subagent has finished
             status = .completed
-        } else if let updated = lastUpdated, Date().timeIntervalSince(updated) > 300 {
-            status = .idle
         } else {
             status = .running
         }

--- a/ClaudeMonitor/Sources/ClaudeMonitor/Presentation/SessionTreeView.swift
+++ b/ClaudeMonitor/Sources/ClaudeMonitor/Presentation/SessionTreeView.swift
@@ -63,6 +63,11 @@ struct SessionTreeView: View {
                         Text("데이터를 가져오는 중...")
                             .font(.caption2)
                             .foregroundStyle(.secondary)
+                    } else if case .fileReadError(let reason) = session.status {
+                        Text(errorReasonText(reason))
+                            .font(.caption)
+                            .foregroundStyle(.orange)
+                            .lineLimit(1)
                     } else {
                         Text(session.tty)
                             .font(.caption)
@@ -187,6 +192,16 @@ struct SessionTreeView: View {
             return String(agentType[agentType.index(after: colonIndex)...])
         }
         return agentType
+    }
+
+    private func errorReasonText(_ reason: FileReadErrorReason) -> String {
+        switch reason {
+        case .noJsonlFile: "JSONL 파일 없음"
+        case .noAssistantMessage: "응답 메시지 없음"
+        case .encodingError: "인코딩 오류"
+        case .pathViolation: "경로 접근 차단"
+        case .unknown: "알 수 없는 오류"
+        }
     }
 
     private func isSessionDataLoading(_ session: SessionInfo) -> Bool {

--- a/ClaudeMonitor/Tests/ClaudeMonitorTests/SessionFileReaderTests.swift
+++ b/ClaudeMonitor/Tests/ClaudeMonitorTests/SessionFileReaderTests.swift
@@ -50,8 +50,8 @@ struct SessionFileReaderTests {
         #expect(snapshot.hasError == false)
     }
 
-    // TC-08: No assistant message
-    @Test("throws noAssistantMessage when no assistant lines")
+    // TC-08: No assistant message → returns partial snapshot with empty text
+    @Test("returns empty text when no assistant lines")
     func noAssistantMessage() async throws {
         let (projectDir, reader) = try setupProjectDir()
         let file = projectDir.appending(path: "session1.jsonl")
@@ -61,9 +61,11 @@ struct SessionFileReaderTests {
         """
         try content.write(to: file, atomically: true, encoding: .utf8)
 
-        await #expect(throws: SessionFileError.noAssistantMessage) {
-            try await reader.readLatestSession(projectDirectory: projectDir)
-        }
+        let snapshot = try await reader.readLatestSession(projectDirectory: projectDir)
+        #expect(snapshot.sessionId == "abc-123")
+        #expect(snapshot.gitBranch == "main")
+        #expect(snapshot.lastAssistantText == "")
+        #expect(snapshot.hasError == false)
     }
 
     // TC-09: Empty directory

--- a/ClaudeMonitor/Tests/ClaudeMonitorTests/SessionStateManagerTests.swift
+++ b/ClaudeMonitor/Tests/ClaudeMonitorTests/SessionStateManagerTests.swift
@@ -59,6 +59,12 @@ final class MockNotificationService: NotificationServiceProtocol, @unchecked Sen
         defer { lock.unlock() }
         return _notifications
     }
+
+    var notificationCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return _notifications.count
+    }
 }
 
 // Thread-safe mutable clock for tests
@@ -155,15 +161,22 @@ struct SessionStateManagerTests {
     @Test("PID terminated without error marks completed and notifies")
     func pidTerminatedNoError() async {
         let scanner = MockProcessScanner()
+        let fileReader = MockSessionFileReader()
         let notifService = MockNotificationService()
-        let (manager, store, _, _, _) = await makeSut(scanner: scanner, notificationService: notifService)
+        let (manager, store, _, _, _) = await makeSut(
+            scanner: scanner, fileReader: fileReader, notificationService: notifService
+        )
 
-        await scanner.setScanResults([
-            [makeProc()],
-            []
-        ])
+        let proc = makeProc()
+        await scanner.setScanResults([[proc], []])
+
+        let pathEncoder = makePathEncoder()
+        if let projectDir = pathEncoder.projectDirectory(for: proc.cwd!) {
+            await fileReader.setResult(for: projectDir, result: .success(makeSnapshot()))
+        }
 
         await manager.pollProcessesOnce()
+        await manager.pollFilesOnce() // Load data so hasEverLoadedData = true
         await manager.pollProcessesOnce()
 
         let sessions = await store.sessions
@@ -213,16 +226,22 @@ struct SessionStateManagerTests {
     @Test("Completed session removed after 30 seconds")
     func completedSessionRemovedAfter30s() async {
         let scanner = MockProcessScanner()
+        let fileReader = MockSessionFileReader()
         let testClock = TestClock()
-        let (manager, store, _, _, _) = await makeSut(scanner: scanner, testClock: testClock)
+        let (manager, store, _, _, _) = await makeSut(
+            scanner: scanner, fileReader: fileReader, testClock: testClock
+        )
 
-        await scanner.setScanResults([
-            [makeProc()],
-            [],
-            []
-        ])
+        let proc = makeProc()
+        await scanner.setScanResults([[proc], [], []])
+
+        let pathEncoder = makePathEncoder()
+        if let projectDir = pathEncoder.projectDirectory(for: proc.cwd!) {
+            await fileReader.setResult(for: projectDir, result: .success(makeSnapshot()))
+        }
 
         await manager.pollProcessesOnce()
+        await manager.pollFilesOnce() // Load data so hasEverLoadedData = true
         await manager.pollProcessesOnce()
 
         var sessions = await store.sessions
@@ -278,9 +297,50 @@ struct SessionStateManagerTests {
         #expect(sessions.isEmpty)
     }
 
-    // TC-SSM-07: JSONL read failure → fileReadError
-    @Test("JSONL read failure sets fileReadError status")
+    // TC-SSM-07: JSONL read failure → fileReadError after threshold (for sessions with prior data)
+    @Test("JSONL read failure sets fileReadError status after consecutive failures")
     func jsonlReadFailureSetsFileReadError() async {
+        let scanner = MockProcessScanner()
+        let fileReader = MockSessionFileReader()
+        let (manager, store, _, _, _) = await makeSut(scanner: scanner, fileReader: fileReader)
+
+        let proc = makeProc()
+        await scanner.setScanResults([[proc]])
+
+        let pathEncoder = makePathEncoder()
+        guard let projectDir = pathEncoder.projectDirectory(for: proc.cwd!) else {
+            Issue.record("Failed to create project directory")
+            return
+        }
+
+        // First: load data successfully (so hasEverLoadedData = true)
+        await fileReader.setResult(for: projectDir, result: .success(makeSnapshot()))
+        await manager.pollProcessesOnce()
+        await manager.pollFilesOnce()
+
+        // Now start failing
+        await fileReader.setResult(for: projectDir, result: .failure(SessionFileError.noJsonlFile))
+
+        // First failure — should stay running
+        await manager.pollFilesOnce()
+        var sessions = await store.sessions
+        #expect(sessions.count == 1)
+        #expect(sessions[0].status == .running)
+
+        // Second failure — should still stay running
+        await manager.pollFilesOnce()
+        sessions = await store.sessions
+        #expect(sessions[0].status == .running)
+
+        // Third failure — should transition to fileReadError
+        await manager.pollFilesOnce()
+        sessions = await store.sessions
+        #expect(sessions[0].status == .fileReadError(reason: .noJsonlFile))
+    }
+
+    // TC-SSM-07b: Session that never loaded data stays running on read failures
+    @Test("Session without prior data never shows fileReadError")
+    func sessionWithoutDataNeverShowsFileReadError() async {
         let scanner = MockProcessScanner()
         let fileReader = MockSessionFileReader()
         let (manager, store, _, _, _) = await makeSut(scanner: scanner, fileReader: fileReader)
@@ -297,11 +357,88 @@ struct SessionStateManagerTests {
         }
 
         await manager.pollProcessesOnce()
-        await manager.pollFilesOnce()
+
+        // Even after many failures, stays running (never loaded data)
+        for _ in 0..<10 {
+            await manager.pollFilesOnce()
+        }
 
         let sessions = await store.sessions
         #expect(sessions.count == 1)
-        #expect(sessions[0].status == .fileReadError(reason: .noJsonlFile))
+        #expect(sessions[0].status == .running)
+    }
+
+    // TC-SSM-07c: Session without data is silently removed on termination
+    @Test("Session without data is silently removed on termination")
+    func sessionWithoutDataRemovedSilentlyOnTermination() async {
+        let scanner = MockProcessScanner()
+        let fileReader = MockSessionFileReader()
+        let notificationService = MockNotificationService()
+        let (manager, store, _, _, _) = await makeSut(
+            scanner: scanner, fileReader: fileReader, notificationService: notificationService
+        )
+
+        let proc = makeProc()
+        await scanner.setScanResults([[proc]])
+
+        let pathEncoder = makePathEncoder()
+        if let projectDir = pathEncoder.projectDirectory(for: proc.cwd!) {
+            await fileReader.setResult(
+                for: projectDir,
+                result: .failure(SessionFileError.noJsonlFile)
+            )
+        }
+
+        await manager.pollProcessesOnce()
+        await manager.pollFilesOnce()
+
+        // Process terminates
+        await scanner.setScanResults([[]])
+        await manager.pollProcessesOnce()
+
+        // Session removed immediately, no notification
+        let sessions = await store.sessions
+        #expect(sessions.isEmpty)
+        #expect(notificationService.notificationCount == 0)
+    }
+
+    // TC-SSM-07d: Successful read resets failure counter
+    @Test("Successful read resets consecutive failure counter")
+    func successfulReadResetsFailureCounter() async {
+        let scanner = MockProcessScanner()
+        let fileReader = MockSessionFileReader()
+        let (manager, store, _, _, _) = await makeSut(scanner: scanner, fileReader: fileReader)
+
+        let proc = makeProc()
+        await scanner.setScanResults([[proc]])
+
+        let pathEncoder = makePathEncoder()
+        guard let projectDir = pathEncoder.projectDirectory(for: proc.cwd!) else {
+            Issue.record("Failed to create project directory")
+            return
+        }
+
+        // Load data first
+        await fileReader.setResult(for: projectDir, result: .success(makeSnapshot()))
+        await manager.pollProcessesOnce()
+        await manager.pollFilesOnce()
+
+        // Two failures (below threshold)
+        await fileReader.setResult(for: projectDir, result: .failure(SessionFileError.noJsonlFile))
+        await manager.pollFilesOnce()
+        await manager.pollFilesOnce()
+
+        // Success resets counter
+        await fileReader.setResult(for: projectDir, result: .success(makeSnapshot()))
+        await manager.pollFilesOnce()
+
+        // Two more failures — should still be running (counter was reset)
+        await fileReader.setResult(for: projectDir, result: .failure(SessionFileError.noJsonlFile))
+        await manager.pollFilesOnce()
+        await manager.pollFilesOnce()
+
+        let sessions = await store.sessions
+        #expect(sessions[0].status == .running)
     }
 
     // TC-SSM-08: fileReadError → running on successful read
@@ -320,15 +457,21 @@ struct SessionStateManagerTests {
             return
         }
 
-        // First: fail
-        await fileReader.setResult(for: projectDir, result: .failure(SessionFileError.noJsonlFile))
+        // First load data, then fail
+        await fileReader.setResult(for: projectDir, result: .success(makeSnapshot()))
         await manager.pollProcessesOnce()
         await manager.pollFilesOnce()
+
+        // Fail enough times to reach fileReadError
+        await fileReader.setResult(for: projectDir, result: .failure(SessionFileError.noJsonlFile))
+        for _ in 0..<SessionStateManager.fileReadErrorThreshold {
+            await manager.pollFilesOnce()
+        }
 
         var sessions = await store.sessions
         #expect(sessions[0].status == .fileReadError(reason: .noJsonlFile))
 
-        // Second: succeed
+        // Succeed → recover to running
         await fileReader.setResult(for: projectDir, result: .success(makeSnapshot()))
         await manager.pollFilesOnce()
 


### PR DESCRIPTION
## Summary
- 파일 읽기 에러 임계값 도입: 3회 연속 실패 후에만 `fileReadError` 표시
- 데이터 미로드 세션 보호: fileReadError/종료 알림 억제, 동일 프로젝트 중복 방지
- 서브에이전트 완료 판정 개선: `hasEndTurn` → 파일 수정 시간 60초 기반
- `noAssistantMessage` 에러 제거: 빈 텍스트 스냅샷으로 대체 (tool 호출 중 에러 방지)
- `tool_use` stop_reason 정상 처리
- 트리뷰에서 fileReadError 시 구체적 이유 표시 (JSONL 파일 없음, 인코딩 오류 등)

## Test plan
- [x] 54개 단위 테스트 통과
- [x] 빌드 성공
- [ ] 서브에이전트 실행 중 메인 세션 안정성 확인
- [ ] fileReadError 발생 시 트리뷰에 이유 표시 확인

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)