### PR TITLE
fix: 멀티바이트 UTF-8 문자 경계에서 파일 인코딩 오류 수정

### DIFF
--- a/ClaudeMonitor/Sources/ClaudeMonitor/Infrastructure/SessionFileReader.swift
+++ b/ClaudeMonitor/Sources/ClaudeMonitor/Infrastructure/SessionFileReader.swift
@@ -75,8 +75,16 @@ actor SessionFileReader: SessionFileReaderProtocol {
         let readSize = min(fileSize, 16 * 1024)
         try handle.seek(toOffset: fileSize - readSize)
 
-        let data = handle.readData(ofLength: Int(readSize))
-        guard let text = String(data: data, encoding: .utf8) else {
+        var data = handle.readData(ofLength: Int(readSize))
+
+        // When reading from an arbitrary offset, we may split a multi-byte
+        // UTF-8 character. Trim up to 3 leading continuation bytes (10xxxxxx)
+        // to find a valid character boundary.
+        while !data.isEmpty && data[data.startIndex] & 0xC0 == 0x80 {
+            data = data.dropFirst()
+        }
+
+        guard let text = String(data: Data(data), encoding: .utf8) else {
             throw SessionFileError.encodingError
         }
         return text

--- a/ClaudeMonitor/Sources/ClaudeMonitor/Infrastructure/SubagentFileReader.swift
+++ b/ClaudeMonitor/Sources/ClaudeMonitor/Infrastructure/SubagentFileReader.swift
@@ -91,8 +91,14 @@ actor SubagentFileReader {
         let readSize = min(fileSize, 16 * 1024)
         try? handle.seek(toOffset: fileSize - readSize)
 
-        let data = handle.readData(ofLength: Int(readSize))
-        guard let text = String(data: data, encoding: .utf8) else { return nil }
+        var data = handle.readData(ofLength: Int(readSize))
+
+        // Trim leading UTF-8 continuation bytes to find a valid character boundary
+        while !data.isEmpty && data[data.startIndex] & 0xC0 == 0x80 {
+            data = data.dropFirst()
+        }
+
+        guard let text = String(data: Data(data), encoding: .utf8) else { return nil }
 
         let lines = text.split(separator: "\n").reversed()
 


### PR DESCRIPTION
## Summary
- `tailRead`에서 파일 중간 오프셋부터 읽을 때 멀티바이트 UTF-8 문자(한글 등)가 잘려서 `String(data:encoding:.utf8)`이 `nil`을 반환하는 버그 수정
- 선행 continuation 바이트(`10xxxxxx`)를 제거하여 유효한 문자 경계를 찾도록 수정
- `SessionFileReader`와 `SubagentFileReader` 모두 적용

## Test plan
- [x] 기존 63개 테스트 전체 통과
- [ ] 한글이 포함된 세션 파일에서 인코딩 오류 미발생 확인

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)